### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: typos-action
-      uses: crate-ci/typos@v1.20.8
+      uses: crate-ci/typos@v1.31.1
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable

--- a/crates/service/src/account.rs
+++ b/crates/service/src/account.rs
@@ -128,7 +128,7 @@ impl Account {
               name,
               public_key
             FROM account
-            WHERE 
+            WHERE
               username = ?
               AND public_key = ?
               AND (type = 'admin' OR type = 'standard');
@@ -156,7 +156,7 @@ impl Account {
               public_key
             )
             VALUES (?,?,?,?,?,?)
-            ON CONFLICT(account_id) DO UPDATE SET 
+            ON CONFLICT(account_id) DO UPDATE SET
               type=excluded.type,
               username=excluded.username,
               email=excluded.email,
@@ -265,10 +265,10 @@ pub(crate) async fn sync_admin(db: &Database, admin: Admin) -> Result<(), Error>
 
     let account: Option<(Uuid,)> = sqlx::query_as(
         "
-        SELECT 
+        SELECT
           account_id
         FROM account
-        WHERE 
+        WHERE
           type = 'admin'
           AND username = ?
           AND name = ?

--- a/crates/service/src/endpoint/service.rs
+++ b/crates/service/src/endpoint/service.rs
@@ -131,7 +131,7 @@ async fn enroll(state: Arc<State>, request: tonic::Request<EnrollmentRequest>) -
 
     debug!(%endpoint, %account, "Generated endpoint & account IDs for enrollment request");
 
-    let recieved = enrollment::Received {
+    let received = enrollment::Received {
         endpoint,
         account,
         remote: enrollment::Remote {
@@ -149,7 +149,7 @@ async fn enroll(state: Arc<State>, request: tonic::Request<EnrollmentRequest>) -
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        if let Err(e) = recieved.accept(&state.db, state.issuer.clone()).await {
+        if let Err(e) = received.accept(&state.db, state.issuer.clone()).await {
             error!(error=%error::chain(e), "Auto accept failed")
         };
     });
@@ -259,7 +259,7 @@ enum Error {
     InvalidPublicKey,
     #[error("Public key not defined in downstreams: {provided}")]
     DownstreamMismatch { provided: PublicKey },
-    #[error("Uknown role: {0}")]
+    #[error("Unknown role: {0}")]
     UnknownRole(i32),
     #[error("Role mismatch, expected {expected:?} provided {provided:?}")]
     RoleMismatch { expected: Role, provided: Role },

--- a/crates/summit/src/repository/reindex.rs
+++ b/crates/summit/src/repository/reindex.rs
@@ -143,7 +143,7 @@ fn install_manifest(db: &meta::Database, work_dir: &Path, manifest: &Path) -> Re
 
     let mut meta = Meta::from_stone_payload(&first.body).context("convert meta payload to metadata")?;
 
-    // Overwrite from root pacakge since we don't know if root package
+    // Overwrite from root package since we don't know if root package
     // was first meta payload that seeded this
     meta.summary = recipe.package.summary.clone().unwrap_or_default();
     meta.description = recipe.package.description.clone().unwrap_or_default();


### PR DESCRIPTION
Automated with `typos -w`.

After I synced my fork, I got a GitHub notification about some typos.