### PR TITLE
Add ability to sort by ended time or build time

### DIFF
--- a/crates/summit/src/routes.rs
+++ b/crates/summit/src/routes.rs
@@ -82,6 +82,8 @@ pub async fn tasks(
             endpoints,
             statuses,
             selected_status,
+            selected_sort,
+            selected_order,
             page,
             total_pages,
             limit,

--- a/crates/summit/src/routes.rs
+++ b/crates/summit/src/routes.rs
@@ -31,8 +31,8 @@ pub struct TasksQuery {
     pub page: Option<NonZeroU32>,
     pub per_page: Option<u32>,
     pub status: Option<task::Status>,
-    pub sort: Option<task::SortField>,
-    pub order: Option<task::SortOrder>,
+    pub sort: Option<task::query::SortField>,
+    pub order: Option<task::query::SortOrder>,
 }
 
 pub async fn tasks(

--- a/crates/summit/src/routes.rs
+++ b/crates/summit/src/routes.rs
@@ -1,4 +1,4 @@
-use std::{iter, num::NonZeroU32};
+use std::{cmp::Ordering, iter, num::NonZeroU32};
 
 use axum::{
     extract::{Query, State},
@@ -31,6 +31,8 @@ pub struct TasksQuery {
     pub page: Option<NonZeroU32>,
     pub per_page: Option<u32>,
     pub status: Option<task::Status>,
+    pub sort: Option<String>,
+    pub order: Option<String>,
 }
 
 pub async fn tasks(
@@ -50,6 +52,8 @@ pub async fn tasks(
     let mut params = task::query::Params::default().offset(offset).limit(limit);
 
     let selected_status = query.status;
+    let selected_sort = query.sort;
+    let selected_order = query.order;
 
     if let Some(status) = selected_status {
         params = params.statuses(iter::once(status));
@@ -57,7 +61,7 @@ pub async fn tasks(
 
     let projects = project::list(&mut conn).await.context("list projects")?;
     let endpoints = Endpoint::list(&mut *conn).await.context("list endpoints")?;
-    let task_query = task::query(&mut conn, params).await.context("query tasks")?;
+    let mut task_query = task::query(&mut conn, params).await.context("query tasks")?;
 
     let statuses = task::Status::iter().collect::<Vec<_>>();
     let total_pages = (task_query.total / limit as usize + 1) as u32;
@@ -66,6 +70,16 @@ pub async fn tasks(
     let start = page.saturating_sub(side_window).max(1);
     let end = (page + side_window).min(total_pages);
     let pages_to_show = (start..=end).collect::<Vec<u32>>();
+
+    if let (Some(sort), Some(order)) = (&selected_sort, &selected_order) {
+        let is_asc = order == "asc";
+
+        match sort.as_str() {
+            "ended" => sort_tasks_by_ended(&mut task_query, is_asc),
+            "build" => sort_tasks_by_build_time(&mut task_query, is_asc),
+            _ => {}
+        }
+    }
 
     Ok(render_html(
         "tasks.html.jinja",
@@ -86,6 +100,36 @@ pub async fn tasks(
 
 pub async fn fallback() -> impl IntoResponse {
     render_html("404.html.jinja", ())
+}
+
+fn sort_tasks_by_ended(task_query: &mut task::query::Query, is_asc: bool) {
+    task_query.tasks.sort_by(|a, b| match (a.ended, b.ended) {
+        (Some(a_time), Some(b_time)) => {
+            if is_asc {
+                a_time.cmp(&b_time)
+            } else {
+                b_time.cmp(&a_time)
+            }
+        }
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
+}
+
+fn sort_tasks_by_build_time(task_query: &mut task::query::Query, is_asc: bool) {
+    task_query.tasks.sort_by(|a, b| match (a.duration, b.duration) {
+        (Some(a_duration), Some(b_duration)) => {
+            if is_asc {
+                a_duration.cmp(&b_duration)
+            } else {
+                b_duration.cmp(&a_duration)
+            }
+        }
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    });
 }
 
 #[derive(Debug, Snafu)]

--- a/crates/summit/src/task.rs
+++ b/crates/summit/src/task.rs
@@ -83,6 +83,22 @@ impl Status {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum SortField {
+    Ended,
+    Build,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "UPPERCASE")]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
 #[derive(Debug, Clone)]
 pub struct Queued {
     pub task: Task,

--- a/crates/summit/src/task.rs
+++ b/crates/summit/src/task.rs
@@ -83,22 +83,6 @@ impl Status {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "lowercase")]
-pub enum SortField {
-    Ended,
-    Build,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
-#[serde(rename_all = "lowercase")]
-#[strum(serialize_all = "UPPERCASE")]
-pub enum SortOrder {
-    Asc,
-    Desc,
-}
-
 #[derive(Debug, Clone)]
 pub struct Queued {
     pub task: Task,

--- a/crates/summit/src/task/query.rs
+++ b/crates/summit/src/task/query.rs
@@ -1,13 +1,29 @@
 use chrono::{DateTime, Utc};
 use color_eyre::eyre::{Context, Result};
 use itertools::Itertools;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sqlx::{Sqlite, SqliteConnection, prelude::FromRow, query::QueryAs, sqlite::SqliteArguments};
 use uuid::Uuid;
 
 use crate::{profile, project, repository};
 
-use super::{Id, SortField, SortOrder, Status, Task};
+use super::{Id, Status, Task};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum SortField {
+    Ended,
+    Build,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, strum::Display, strum::EnumString)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "UPPERCASE")]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
 
 #[derive(Debug, Default)]
 pub struct Params {

--- a/crates/summit/static/style.css
+++ b/crates/summit/static/style.css
@@ -445,6 +445,37 @@ header h1 {
     background: var(--light-background-color);
 }
 
+.custom-select-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+.custom-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    width: 100%;
+    padding: 2px 30px 2px 10px;
+    border: 1px solid var(--light-border-color);
+    border-radius: 4px;
+    background-color: var(--light-background-color);
+    background-image: none;
+    cursor: pointer;
+    color: var(--body-text-color);
+    font-size: 0.8em;
+}
+
+.custom-select-wrapper::after {
+    content: "▼";
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    font-size: 12px;
+    color: var(--body-text-color);
+}
+
 @media (max-width: 480px) {
     .page-link {
         padding: 0.4em 0.6em;
@@ -469,6 +500,10 @@ header h1 {
 
     .tasks-total-filter span:nth-child(2) {
         display: block;
+    }
+
+    .tasks-total-filter__sort {
+        margin-left: auto;
     }
 
     .tasks__list__item {

--- a/crates/summit/templates/skel.html.jinja
+++ b/crates/summit/templates/skel.html.jinja
@@ -30,6 +30,7 @@
     <div class="container">
         {% block body %}{% endblock %}
     </div>
+    {% block javascript %}{% endblock %}
 </body>
 
 </html>

--- a/crates/summit/templates/tasks.html.jinja
+++ b/crates/summit/templates/tasks.html.jinja
@@ -9,6 +9,18 @@
                 <a href="/tasks?status={{ status }}">{{ status }}</a>
             {% endfor %}
         </span>
+        <span class="tasks-total-filter__sort">
+            <span>Sort by:</span>
+            <div class="custom-select-wrapper">
+                <select class="custom-select" id="taskSortSelect">
+                    <option value="">Default</option>
+                    <option value="sort=ended&order=desc">Newest Finished</option>
+                    <option value="sort=ended&order=asc">Oldest Finished</option>
+                    <option value="sort=build&order=asc">Shortest Build Time</option>
+                    <option value="sort=build&order=desc">Longest Build Time</option>
+                </select>
+            </div>
+        </span>
     </div>
 
     <div class="tasks">
@@ -115,4 +127,31 @@
         </nav>
     {% endif %}
 
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        const taskSortSelect = document.getElementById('taskSortSelect');
+
+        document.addEventListener('DOMContentLoaded', function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const sort = urlParams.get('sort');
+            const order = urlParams.get('order');
+
+            if (sort && order) {
+                const queryValue = `sort=${sort}&order=${order}`;
+
+                for (const option of taskSortSelect.options) {
+                    if (option.value === queryValue) {
+                        option.selected = true;
+                        break;
+                    }
+                }
+            }
+        });
+
+        taskSortSelect.addEventListener('change', function(e) {
+            window.location.href = '?' + this.value;
+        });
+    </script>
 {% endblock %}

--- a/crates/summit/templates/tasks.html.jinja
+++ b/crates/summit/templates/tasks.html.jinja
@@ -75,12 +75,15 @@
         {% if selected_status is not none -%}
             {% set and_status_filter = '&status=' ~ selected_status -%}
         {% endif -%}
+        {% if selected_sort is not none and selected_order is not none -%}
+            {% set and_sort_order = '&sort=' ~ selected_sort ~ '&order=' ~ selected_order -%}
+        {% endif -%}
         <nav class="pagination-wrap" aria-label="Pagination">
             <ul class="pagination">
 
                 {# Previous Button #}
                 <li class="page-item {% if page <= 1 %}disabled{% endif %}">
-                    <a class="page-link" href="?page={{ page - 1 }}{{ and_status_filter }}" aria-label="Previous">
+                    <a class="page-link" href="?page={{ page - 1 }}{{ and_status_filter }}{{ and_sort_order }}" aria-label="Previous">
                         <span aria-hidden="true">&laquo;</span>
                     </a>
                 </li>
@@ -88,7 +91,7 @@
                 {# First page + ellipsis if not in pages_to_show #}
                 {% if pages_to_show[0] > 1 %}
                     <li class="page-item">
-                        <a class="page-link" href="?page=1{{ and_status_filter }}">1</a>
+                        <a class="page-link" href="?page=1{{ and_status_filter }}{{ and_sort_order }}">1</a>
                     </li>
                     {% if pages_to_show[0] > 2 %}
                         <li class="page-item disabled">
@@ -100,7 +103,7 @@
                 {# Page Numbers #}
                 {% for p in pages_to_show %}
                     <li class="page-item {% if p == page %}active{% endif %}">
-                        <a class="page-link" href="?page={{ p }}{{ and_status_filter }}">{{ p }}</a>
+                        <a class="page-link" href="?page={{ p }}{{ and_status_filter }}{{ and_sort_order }}">{{ p }}</a>
                     </li>
                 {% endfor %}
 
@@ -112,13 +115,13 @@
                         </li>
                     {% endif %}
                     <li class="page-item">
-                        <a class="page-link" href="?page={{ total_pages }}{{ and_status_filter }}">{{ total_pages }}</a>
+                        <a class="page-link" href="?page={{ total_pages }}{{ and_status_filter }}{{ and_sort_order }}">{{ total_pages }}</a>
                     </li>
                 {% endif %}
 
                 {# Next Button #}
                 <li class="page-item {% if page >= total_pages %}disabled{% endif %}">
-                    <a class="page-link" href="?page={{ page + 1 }}{{ and_status_filter }}" aria-label="Next">
+                    <a class="page-link" href="?page={{ page + 1 }}{{ and_status_filter }}{{ and_sort_order }}" aria-label="Next">
                         <span aria-hidden="true">&raquo;</span>
                     </a>
                 </li>


### PR DESCRIPTION
Fixes #72 

Basic sorting for ended time or build time. Currently it doesn't include the status type because ordering right now only really makes sense for All or Completed.

Sorting methods were done with a little AI help.

Had to use a little Javascript for the drop down selection.

Hopefully this is what you were looking for.

