### PR TITLE
summit: Add very crude data mocking

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,7 +34,12 @@ down *ARGS:
 
 # Quickly view summit front-end changes (DX feature)
 summit-dev *ARGS:
-	cargo run -p summit --no-default-features --features templates-autoreload -- -c ./test/summit/config.toml --root $(mktemp -d) --static ./crates/summit/static {{ARGS}}
+	cargo run -p summit --no-default-features --features templates-autoreload -- \
+		-c ./test/summit/config.toml \
+		--root $(mktemp -d) \
+		--static ./crates/summit/static \
+		--use-mock-data \
+		{{ARGS}}
 
 # Do a fresh build of 'avalanche|summit|vessel', stop it, reset it, deploy it, and start it.
 reset-then-deploy *ARGS:


### PR DESCRIPTION
I can render a non-empty task list with `just summit-dev` now!

I think this shouldn't get in the way for anything else so I'd be glad if we could merge this as-is, but of course there's a lot of ways this can be improved:

- Put the new command-line flag behind a compile-time feature? (so regular / release builds of summit don't even have this command-line flag)
- More mock data
- More realistic mock data
- Mock data for other resources (projects, endpoints, repositories, profiles)

![Screenshot 2025-05-15 at 23-40-48 Summit](https://github.com/user-attachments/assets/b8e21b4e-54a3-4c4f-9cae-cc7607cc2492)
