### PR TITLE
fix: enable authenticate for all account types

### DIFF
--- a/crates/service/src/account.rs
+++ b/crates/service/src/account.rs
@@ -130,8 +130,7 @@ impl Account {
             FROM account
             WHERE
               username = ?
-              AND public_key = ?
-              AND (type = 'admin' OR type = 'standard');
+              AND public_key = ?;
             ",
         )
         .bind(username)


### PR DESCRIPTION
This is a bug from some old code where `/account/authenticate` was originally only intended for admin / user accounts and services had older endpoint / enrollment APIs for refreshing tokens (from D), but that got scrapped and now the `/account` auth / refresh token APIs are used by services as well xD

So every 7 days when the bearer token expires, our services would try to re-authenticate but we couldn't look up their info in that code path because we filtered for only admin / standard accounts and not service accounts so it never worked... ooops