### PR TITLE
cancel in-flight build when cancelling a task

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::eyre::Result;
 use service_client::{AuthClient, CredentialsAuth, SummitServiceClient};
 use service_core::crypto::KeyPair;
-use service_grpc::summit::{FailRequest, RetryRequest};
+use service_grpc::summit::{CancelRequest, RetryRequest};
 use tokio::{fs, io};
 use tonic::transport::Uri;
 
@@ -30,8 +30,8 @@ async fn main() -> Result<()> {
                 Summit::Retry { task } => {
                     client.retry(RetryRequest { task_id: task }).await?;
                 }
-                Summit::Fail { task } => {
-                    client.fail(FailRequest { task_id: task }).await?;
+                Summit::Cancel { task } => {
+                    client.cancel(CancelRequest { task_id: task }).await?;
                 }
                 Summit::Refresh {} => {
                     client.refresh(()).await?;
@@ -115,8 +115,8 @@ enum Summit {
         /// Task id
         task: u64,
     },
-    /// Fail an in progress task
-    Fail {
+    /// Cancel an in progress task
+    Cancel {
         /// Task id
         task: u64,
     },

--- a/crates/service-core/src/auth.rs
+++ b/crates/service-core/src/auth.rs
@@ -49,7 +49,7 @@ impl Role {
         use Permission::*;
 
         match self {
-            Role::Admin => [RetryTask, FailTask, Refresh].into_iter().collect(),
+            Role::Admin => [RetryTask, CancelTask, Refresh].into_iter().collect(),
             Role::Hub => [RequestUploadToken].into_iter().collect(),
             Role::RepositoryManager => [ReportImportStatus].into_iter().collect(),
             Role::Builder => [ConnectBuilderStream].into_iter().collect(),
@@ -72,8 +72,8 @@ pub enum Permission {
     ConnectBuilderStream,
     /// Retry a task
     RetryTask,
-    /// Fail a task
-    FailTask,
+    /// Cancel a task
+    CancelTask,
     /// Force refresh all projects
     Refresh,
 }

--- a/crates/service-grpc/proto/summit.proto
+++ b/crates/service-grpc/proto/summit.proto
@@ -15,7 +15,7 @@ message RetryRequest {
   uint64 task_id = 1;
 }
 
-message FailRequest {
+message CancelRequest {
   uint64 task_id = 1;
 }
 
@@ -34,6 +34,7 @@ message BuilderStreamOutgoing {
   oneof event {
     BuilderBuild build = 1;
     BuilderUpload upload = 2;
+    google.protobuf.Empty cancel_build = 3;
   }
 }
 
@@ -91,9 +92,9 @@ service SummitService {
     option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
     option (options.perm) = "RetryTask";
   }
-  rpc Fail(FailRequest) returns (google.protobuf.Empty) {
+  rpc Cancel(CancelRequest) returns (google.protobuf.Empty) {
     option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
-    option (options.perm) = "FailTask";
+    option (options.perm) = "CancelTask";
   }
   rpc Refresh(google.protobuf.Empty) returns (google.protobuf.Empty) {
     option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";

--- a/crates/summit/src/queue.rs
+++ b/crates/summit/src/queue.rs
@@ -155,8 +155,8 @@ impl Queue {
         Ok(())
     }
 
-    #[tracing::instrument(name = "queue_task_failed", skip_all, fields(%task_id))]
-    pub async fn task_failed(&mut self, tx: &mut Transaction, task_id: task::Id) -> Result<()> {
+    #[tracing::instrument(name = "queue_add_blockers", skip_all, fields(%task_id))]
+    pub async fn add_blockers(&mut self, tx: &mut Transaction, task_id: task::Id) -> Result<()> {
         let idx = self
             .0
             .iter()
@@ -188,8 +188,8 @@ impl Queue {
         Ok(())
     }
 
-    #[tracing::instrument(name = "queue_task_completed", skip_all, fields(%task_id))]
-    pub async fn task_completed(&mut self, tx: &mut Transaction, task_id: task::Id) -> Result<()> {
+    #[tracing::instrument(name = "queue_remove_blockers", skip_all, fields(%task_id))]
+    pub async fn remove_blockers(&mut self, tx: &mut Transaction, task_id: task::Id) -> Result<()> {
         let idx = self
             .0
             .iter()

--- a/crates/summit/src/task.rs
+++ b/crates/summit/src/task.rs
@@ -69,6 +69,8 @@ pub enum Status {
     New,
     /// Failed execution or evaluation
     Failed,
+    /// Cancelled execution
+    Cancelled,
     /// This task is now building
     Building,
     /// Now publishing to Vessel
@@ -90,7 +92,10 @@ pub enum Status {
 
 impl Status {
     pub fn is_open(&self) -> bool {
-        !matches!(self, Status::Completed | Status::Failed | Status::Superseded)
+        !matches!(
+            self,
+            Status::Completed | Status::Failed | Status::Cancelled | Status::Superseded
+        )
     }
 
     pub fn is_in_progress(&self) -> bool {

--- a/crates/summit/src/task/create.rs
+++ b/crates/summit/src/task/create.rs
@@ -60,9 +60,12 @@ pub(super) async fn create(
                 Status::Blocked | Status::New => true,
                 // Tasks already building / publishing shouldn't get cancelled & should have their
                 // lifecycle finished since they're already in-flight
-                Status::Building | Status::Completed | Status::Failed | Status::Publishing | Status::Superseded => {
-                    false
-                }
+                Status::Building
+                | Status::Publishing
+                | Status::Completed
+                | Status::Failed
+                | Status::Cancelled
+                | Status::Superseded => false,
             }))
             .source_path(source_path.clone()),
     )

--- a/crates/summit/src/worker.rs
+++ b/crates/summit/src/worker.rs
@@ -21,7 +21,7 @@ pub enum Message {
     ImportSucceeded { task_id: task::Id },
     ImportFailed { task_id: task::Id },
     RetryTask { task_id: task::Id },
-    FailTask { task_id: task::Id },
+    CancelTask { task_id: task::Id },
     Timer(Instant),
     ForceRefresh,
     Builder(endpoint::Id, builder::Message),
@@ -71,7 +71,7 @@ async fn handle_message(sender: &Sender, manager: &mut Manager, message: Message
         Message::ImportSucceeded { task_id } => import_succeeded(sender, manager, task_id).await,
         Message::ImportFailed { task_id } => import_failed(sender, manager, task_id).await,
         Message::RetryTask { task_id } => retry_task(sender, manager, task_id).await,
-        Message::FailTask { task_id } => fail_task(sender, manager, task_id).await,
+        Message::CancelTask { task_id } => cancel_task(sender, manager, task_id).await,
         Message::Timer(_) => timer(sender, manager).await,
         Message::ForceRefresh => force_refresh(sender, manager).await,
         Message::Builder(endpoint, message) => {
@@ -132,10 +132,10 @@ async fn retry_task(sender: &Sender, manager: &mut Manager, task_id: task::Id) -
 }
 
 #[tracing::instrument(skip_all)]
-async fn fail_task(sender: &Sender, manager: &mut Manager, task_id: task::Id) -> Result<()> {
-    debug!("Fail task");
+async fn cancel_task(sender: &Sender, manager: &mut Manager, task_id: task::Id) -> Result<()> {
+    debug!("Cancel task");
 
-    manager.fail_task(task_id).await.context("manager fail task")?;
+    manager.cancel_task(task_id).await.context("manager cancel task")?;
 
     let _ = sender.send(Message::AllocateBuilds);
 

--- a/test/summit/seed.toml
+++ b/test/summit/seed.toml
@@ -13,6 +13,11 @@ name = "volatile"
 uri = "https://packages.aerynos.com/volatile/x86_64/stone.index"
 priority = 10
 
+[[project.profile.remote]]
+name = "volatile"
+uri = "https://build.aerynos.dev/volatile/x86_64/stone.index"
+priority = 20
+
 [[project.repository]]
 name = "recipes"
 summary = "Test recipes"


### PR DESCRIPTION
Renames `fail task` to `cancel task` and adds a new `Cancelled` status to indicate when tasks have been "cancelled".

When cancelling a task, it now sends a command to the builder to cancel the task on the builder. This ensures the task doesn't keep building and also gives us a path to cancel "stuck" builds and free up the builder without having to restart it.