### PR TITLE
Fix/avalanche upload failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,9 +4360,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tonic"
-version = "0.14.1"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ac5a8627ada0968acec063a4746bf79588aa03ccb66db2f75d7dce26722a40"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",

--- a/crates/avalanche/src/stream.rs
+++ b/crates/avalanche/src/stream.rs
@@ -208,14 +208,22 @@ async fn connect_inner(
                         }
                         builder_stream_outgoing::Event::Upload(BuilderUpload { build, token, uri }) => {
                             let build = build.ok_or_eyre("missing build message")?;
+                            let task_id = build.task_id;
 
                             tokio::spawn({
                                 let state = state.clone();
+                                let sender = sender.clone();
 
                                 async move {
                                     if let Err(e) = upload(state, build, token, &uri).await {
                                         let error = error::chain(&*e);
-                                        error!(uri, %error, "Failed to upload packages to vessel");
+                                        error!(uri, task_id, %error, "Failed to upload packages to vessel");
+
+                                        let _ = sender
+                                            .send(BuilderStreamIncoming {
+                                                event: Some(builder_stream_incoming::Event::UploadFailed(task_id)),
+                                            })
+                                            .await;
                                     }
                                 }
                             });

--- a/crates/service-client/src/lib.rs
+++ b/crates/service-client/src/lib.rs
@@ -104,7 +104,8 @@ macro_rules! service_client {
             {
                 let mut endpoint = ::tonic::transport::Endpoint::new(uri)?
                     .http2_keep_alive_interval(Duration::from_secs(60))
-                    .keep_alive_timeout(Duration::from_secs(20));
+                    .keep_alive_timeout(Duration::from_secs(20))
+                    .connect_timeout(Duration::from_secs(5));
 
                 if let Some(config) = tls_config {
                     endpoint = endpoint.tls_config(config.load().await?)?;
@@ -130,7 +131,8 @@ macro_rules! service_client {
             > {
                 let mut endpoint = ::tonic::transport::Endpoint::new(uri)?
                     .http2_keep_alive_interval(Duration::from_secs(60))
-                    .keep_alive_timeout(Duration::from_secs(20));
+                    .keep_alive_timeout(Duration::from_secs(20))
+                    .connect_timeout(Duration::from_secs(5));
 
                 if let Some(config) = tls_config {
                     endpoint = endpoint.tls_config(config.load().await?)?;

--- a/crates/service-grpc/proto/summit.proto
+++ b/crates/service-grpc/proto/summit.proto
@@ -27,6 +27,7 @@ message BuilderStreamIncoming {
     BuilderFinished build_succeeded = 4;
     uint64 build_failed = 5;
     BuilderBusy busy = 6;
+    uint64 upload_failed = 7;
   }
 }
 

--- a/crates/summit/src/builder.rs
+++ b/crates/summit/src/builder.rs
@@ -46,6 +46,9 @@ pub enum Message {
         requested: task::Id,
         in_progress: Option<task::Id>,
     },
+    UploadFailed {
+        task_id: task::Id,
+    },
 }
 
 #[derive(Debug)]
@@ -63,6 +66,9 @@ pub enum Event {
         log_path: Option<PathBuf>,
     },
     BuildRejected {
+        task_id: task::Id,
+    },
+    UploadFailed {
         task_id: task::Id,
     },
 }
@@ -354,6 +360,11 @@ impl Builder {
                 }
 
                 return Some(Event::BuildRejected { task_id: requested });
+            }
+            Message::UploadFailed { task_id } => {
+                info!(%task_id, "Upload failed");
+
+                return Some(Event::UploadFailed { task_id });
             }
         }
 

--- a/crates/summit/src/grpc.rs
+++ b/crates/summit/src/grpc.rs
@@ -420,6 +420,15 @@ async fn builder(
                         },
                     ));
                 }
+                builder_stream_incoming::Event::UploadFailed(task_id) => {
+                    let _ = state.worker.send(worker::Message::Builder(
+                        endpoint_id,
+                        public_key.clone(),
+                        builder::Message::UploadFailed {
+                            task_id: (task_id as i64).into(),
+                        },
+                    ));
+                }
             }
         }
 

--- a/crates/summit/src/manager.rs
+++ b/crates/summit/src/manager.rs
@@ -679,6 +679,24 @@ impl Manager {
                     // Task needs to be queued up on a new builder
                     return Ok(true);
                 }
+                builder::Event::UploadFailed { task_id } => {
+                    let mut tx = self.state.service_db().begin().await?;
+
+                    task::transition(
+                        &mut tx,
+                        task_id,
+                        task::Transition::Failed {
+                            stashed_build_logs: None,
+                        },
+                        &self.queue,
+                    )
+                    .await
+                    .context(format!("transition task {task_id} to failed"))?;
+
+                    tx.commit().await?;
+
+                    let _ = self.event_sender.try_send(Event::TasksUpdated);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes two issues:

- Adds a connect timeout so our grpc clients fail to connect after 5 seconds (dns resolution, etc)
- If avalanche fails to upload to vessel, it reports this failure back to summit so the task is failed instead of it getting stuck as "publishing"