### PR TITLE
Task/post v0 productisation items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5052,6 +5052,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tonic-prost-build = "0.14.1"
 tracing = "0.1.40"
 url = "2.5.2"
 petgraph = "0.8.2"
+zstd = "0.13.2"
 
 clap = { version = "4.4", features = ["derive"] }
 derive_more = { version = "2.0.1", features = ["display", "from", "into", "as_ref"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git <<"EOT" /bin/sh
     git clone https://github.com/AerynOS/os-tools /tools
     cd /tools
-    # TODO: Remove
-    git checkout task/moss-repo-format
     cargo install --path ./boulder
 EOT
 ARG RUST_PROFILE="release"

--- a/crates/service/src/process.rs
+++ b/crates/service/src/process.rs
@@ -4,7 +4,7 @@ use std::{
     process::{ExitStatus, Stdio},
 };
 
-use tokio::process::{ChildStderr, ChildStdout, Command};
+use tokio::process::{Child, ChildStderr, ChildStdout, Command};
 use tracing::trace;
 
 /// Execute the command and return it's stdout output
@@ -43,18 +43,20 @@ where
 
     let mut process = Command::new(command);
 
-    let mut child = f(&mut process)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|err| Error::Io(command.to_owned(), err))?;
+    let mut child = KillOnDrop(
+        f(&mut process)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|err| Error::Io(command.to_owned(), err))?,
+    );
 
-    let stdout = child.stdout.take().expect("stdout set explicitly");
-    let stderr = child.stderr.take().expect("stderr set explicitly");
+    let stdout = child.0.stdout.take().expect("stdout set explicitly");
+    let stderr = child.0.stderr.take().expect("stderr set explicitly");
 
     let task = tokio::spawn(piped(stdout, stderr));
 
-    let status = child.wait().await.map_err(|err| Error::Io(command.to_owned(), err))?;
+    let status = child.0.wait().await.map_err(|err| Error::Io(command.to_owned(), err))?;
 
     let _ = task.await;
 
@@ -79,4 +81,12 @@ pub enum Error {
     /// Process failed with provided stderr
     #[error("{0} failed: {1}: {2}")]
     FailedWithOutput(String, ExitStatus, String),
+}
+
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        let _ = self.0.start_kill();
+    }
 }

--- a/crates/vessel/Cargo.toml
+++ b/crates/vessel/Cargo.toml
@@ -36,6 +36,7 @@ tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
 natural-sort-rs.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
 test-case.workspace = true

--- a/crates/vessel/src/channel.rs
+++ b/crates/vessel/src/channel.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::io;
-use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{self, Context, OptionExt, Result, bail, ensure, eyre};
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use moss::repository::{Format, format};
 use service::database::Transaction;
 use stone::{StoneDecodedPayload, StoneHeader, StoneHeaderV1FileType, StoneWriter};
+use tokio::task::spawn_blocking;
 use tokio::time::Instant;
 use tracing::{debug, info, info_span, warn};
 
@@ -266,7 +267,7 @@ pub async fn import_packages(
     destructive_move: bool,
 ) -> Result<()> {
     // Stone is read in blocking manner
-    let (mut tx, format, mut entries) = tokio::task::spawn_blocking({
+    let (mut tx, format, mut entries) = spawn_blocking({
         let span = tracing::Span::current();
         let state = state.clone();
         let channel = channel.to_owned();
@@ -471,7 +472,7 @@ async fn reindex(state: &State, channel: &str, version: &Version, format: &Forma
     let now = Instant::now();
 
     // Write stone is blocking
-    tokio::task::spawn_blocking({
+    spawn_blocking({
         let span = tracing::Span::current();
         let state = state.clone();
         let history = history.clone();
@@ -710,34 +711,48 @@ async fn update_root_index_json(state: &State, channel: &str) -> Result<()> {
 
     let json = serde_json::to_string_pretty(&root_index).context("serialize root index json")?;
 
-    let temp_path = tempfile::Builder::new()
-        .prefix("vessel-moss-root-index")
-        .permissions(std::fs::Permissions::from_mode(0o644))
-        .tempfile()
-        .context("open temp file")?
-        .into_temp_path();
+    let json_zstd = spawn_blocking({
+        let json = json.clone();
+        move || zstd::encode_all(json.as_bytes(), -1)
+    })
+    .await
+    .context("spawn blocking")?
+    .context("encode root index json as zstd")?;
 
-    fs::write(&temp_path, json)
+    let temp_dir = tempfile::TempDir::with_prefix("vessel-moss-root-index").context("create temp dir")?;
+
+    let temp_json_path = temp_dir.path().join("moss-root-index.json");
+    let temp_json_zstd_path = temp_json_path.with_extension("json.zst");
+
+    fs::write(&temp_json_path, json)
         .await
         .context("write moss-root-index.json")?;
+    fs::write(&temp_json_zstd_path, json_zstd)
+        .await
+        .context("write moss-root-index.json.zst")?;
 
-    let path = state.public_dir().join(channel).join("moss-root-index.json");
+    let json_path = state.public_dir().join(channel).join("moss-root-index.json");
+    let json_zstd_path = json_path.with_extension("json.zst");
 
-    // Attempt atomic rename or fallback to copy
-    match fs::rename(&temp_path, &path).await {
-        Ok(_) => {}
-        Err(err) if err.kind() == io::ErrorKind::CrossesDevices => {
-            fs::copy(&temp_path, &path)
-                .await
-                .context("copy moss-root-index.json temp to final")?;
-            fs::remove_file(&temp_path)
-                .await
-                .context("remove moss-root-index.json temp path")?;
-        }
-        Err(err) => {
-            return Err(err).context("rename moss-root-index.json temp to final");
+    for (source, dest) in [(temp_json_path, json_path), (temp_json_zstd_path, json_zstd_path)] {
+        let file_name = dest.file_name().unwrap_or_default().to_str().unwrap_or_default();
+
+        // Attempt atomic rename or fallback to copy
+        match fs::rename(&source, &dest).await {
+            Ok(_) => {}
+            Err(err) if err.kind() == io::ErrorKind::CrossesDevices => {
+                fs::copy(&source, &dest)
+                    .await
+                    .with_context(|| format!("copy {file_name} temp to final"))?;
+            }
+            Err(err) => {
+                return Err(err).with_context(|| format!("rename {file_name} temp to final"));
+            }
         }
     }
+
+    // Cleanup temp dir
+    drop(temp_dir);
 
     Ok(())
 }

--- a/justfile
+++ b/justfile
@@ -5,14 +5,14 @@ help:
 	@just --list
 
 [private]
-docker-build target profile:
-	@docker build . -t serpentos/{{target}}:{{profile}} --target {{target}} --build-arg RUST_PROFILE={{profile}}
+docker-build target profile *ARGS:
+	@docker build . -t serpentos/{{target}}:{{profile}} --target {{target}} --build-arg RUST_PROFILE={{profile}} {{ARGS}}
 
 # Build docker containers
-build profile="dev": (docker-build "summit" profile) (docker-build "avalanche" profile) (docker-build "vessel" profile)
+build profile="infratest" *ARGS: (docker-build "summit" profile ARGS) (docker-build "avalanche" profile ARGS) (docker-build "vessel" profile ARGS)
 
 # Bring up docker containers
-up *ARGS: (_up "dev" ARGS)
+up *ARGS: (_up "infratest" ARGS)
 
 # Bring up docker containers in release mode
 up-release *ARGS: (_up "release" ARGS)

--- a/test/Caddyfile
+++ b/test/Caddyfile
@@ -26,6 +26,8 @@
 
 		handle {
 			file_server {
+				precompressed zstd
+				hide *.zst
 				browse {
 					reveal_symlinks
 				}

--- a/test/summit/seed.toml
+++ b/test/summit/seed.toml
@@ -14,9 +14,12 @@ version = "stream/volatile"
 
 [[project.profile.remote]]
 name = "volatile"
-# TODO: Update to new index format once its live
-index.uri = "https://cdn.aerynos.dev/stream/volatile/x86_64/stone.index"
 priority = 10
+
+[project.profile.remote.index]
+base_uri = "https://cdn.aerynos.dev"
+channel = "main"
+version = "stream/volatile"
 
 [[project.repository]]
 name = "recipes"


### PR DESCRIPTION
This PR contains a couple of post Versioned Repos, phase 2 productisation features:

## Ensure Avalanche build middleware properly kills cancelled tasks

The previous implementation only `Drop`'ed the `Future` associated with a task, without actually ensuring that the underlying build process was killed.

Fix this by explicitly killing the underlying build process.

Resolves #165 

---

## Optimization for moss-root-index.json download bandwidth usage

As a small optimization of download bandwidth per #162 , we now "precompress" `moss-root-index.json` with `zstd -1` as `moss-root-index.json.zst` next to the original file. 

### Web browser scenario

We then use the `precompressed` configuration option with Caddy, so caddy will respect `Accept-Encoding: zstd` and serve clients the `moss-root-index.json.zst` file transparently instead of the uncompressed file, and in the process setting the `Content-Encoding` property, so the client can transparently decode it.

If the browser client cannot not transparently decode the .zst stream, caddy falls back to serving the plain .json file.

### Moss client scenario

With `moss`, we use the `zstd` feature flag in the reqwest library, which automagically adds the `Accept-Encoding: zstd` header and does the decoding for us.

This means that we don't need to make any changes to moss to benefit from offering the compressed `moss-root-index.json.zst` file.

Resolves #162 
