### PR TITLE
Migrate to session backed auth

### DIFF
--- a/crates/avalanche/src/upload.rs
+++ b/crates/avalanche/src/upload.rs
@@ -30,8 +30,6 @@ pub async fn upload(state: State, build: BuildFinished, token: String, uri: &str
     let mut header = BytesMut::new();
     build.encode(&mut header).context("encode header")?;
 
-    let signature = state.key_pair.sign(&header);
-
     let mut client = VesselServiceClient::connect_with_token(uri.parse().context("invalid vessel uri")?, None, &token)
         .await
         .context("connect vessel client")?;
@@ -46,12 +44,6 @@ pub async fn upload(state: State, build: BuildFinished, token: String, uri: &str
 
     sender
         .send(UploadRequest { chunk: header.into() })
-        .await
-        .context("send header")?;
-    sender
-        .send(UploadRequest {
-            chunk: signature.to_vec(),
-        })
         .await
         .context("send header")?;
 

--- a/crates/service-core/src/auth.rs
+++ b/crates/service-core/src/auth.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
-use crate::{Service, account, crypto::PublicKey};
+use crate::{Service, crypto::PublicKey};
 
 bitflags! {
     /// Authorization flags that describe the account making the request
@@ -20,6 +20,20 @@ bitflags! {
         const EXPIRED = 1 << 2;
         /// Token is not expired
         const NOT_EXPIRED = 1 << 3;
+        /// Valid session
+        const VALID_SESSION = 1 << 4;
+
+        /// A valid session w/ non-expired access token
+        const SESSION_ACCESS =
+            Self::ACCESS_TOKEN.bits()
+            | Self::NOT_EXPIRED.bits()
+            | Self::VALID_SESSION.bits();
+
+        /// A valid session w/ non-expired refresh / bearer token
+        const SESSION_REFRESH =
+            Self::BEARER_TOKEN.bits()
+            | Self::NOT_EXPIRED.bits()
+            | Self::VALID_SESSION.bits();
     }
 }
 
@@ -98,54 +112,6 @@ pub enum Permission {
     UpgradeFormat,
 }
 
-/// An authorized client
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
-#[serde(rename_all = "kebab-case", tag = "type")]
-pub enum Client {
-    /// Account client
-    #[strum(serialize = "account(id={account_id}, kind={account_kind}, public_key={public_key})")]
-    Account {
-        /// Account id
-        account_id: account::Id,
-        /// Account kind
-        account_kind: account::Kind,
-        /// Public key of account
-        public_key: PublicKey,
-    },
-    /// Service client
-    #[strum(serialize = "service(id={service_id}, service={service}, public_key={public_key})")]
-    Service {
-        /// Service id
-        service_id: String,
-        /// Service
-        service: Service,
-        /// Public key of service
-        public_key: PublicKey,
-    },
-}
-
-impl Client {
-    /// The client's [`PublicKey`]
-    pub fn public_key(&self) -> PublicKey {
-        match self {
-            Client::Account { public_key, .. } => *public_key,
-            Client::Service { public_key, .. } => *public_key,
-        }
-    }
-
-    /// The client's [`Role`], if any
-    pub fn role(&self) -> Option<Role> {
-        match self {
-            Client::Account { account_kind, .. } => matches!(account_kind, account::Kind::Admin).then_some(Role::Admin),
-            Client::Service { service, .. } => Some(match service {
-                Service::Summit => Role::Hub,
-                Service::Avalanche => Role::Builder,
-                Service::Vessel => Role::RepositoryManager,
-            }),
-        }
-    }
-}
-
 /// A unique service which is allowed to authorize
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct AuthorizedService {
@@ -162,3 +128,33 @@ pub struct AuthorizedService {
 /// If the same [`PublicKey`] is added, it will overwrite any
 /// previous service entry.
 pub type AuthorizedServices = HashMap<PublicKey, AuthorizedService>;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_required_flags() {
+        const REQUIRED_FLAGS: Flags = Flags::SESSION_ACCESS;
+
+        let valid = [
+            Flags::NOT_EXPIRED | Flags::ACCESS_TOKEN | Flags::VALID_SESSION,
+            Flags::all(),
+        ];
+
+        let not_valid = [
+            Flags::empty(),
+            Flags::NO_AUTH,
+            Flags::SESSION_REFRESH,
+            Flags::all() & !Flags::VALID_SESSION,
+        ];
+
+        for actual in valid {
+            assert!(actual.contains(REQUIRED_FLAGS));
+        }
+
+        for actual in not_valid {
+            assert!(!actual.contains(REQUIRED_FLAGS));
+        }
+    }
+}

--- a/crates/service-core/src/lib.rs
+++ b/crates/service-core/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(missing_docs)]
 
 pub use self::service::Service;
+pub use self::session::Session;
 pub use self::token::Token;
 
 mod service;
@@ -10,4 +11,5 @@ mod service;
 pub mod account;
 pub mod auth;
 pub mod crypto;
+pub mod session;
 pub mod token;

--- a/crates/service-core/src/session.rs
+++ b/crates/service-core/src/session.rs
@@ -1,0 +1,145 @@
+//! Session management
+
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    time::SystemTime,
+};
+
+use chrono::{DateTime, Utc};
+use derive_more::{AsRef, Display, From, Into};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{Service, account, auth, crypto::PublicKey};
+
+/// Unique [`Session`] identifier
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, From, Into, Display, AsRef)]
+pub struct Id(Uuid);
+
+impl Id {
+    /// Generate a new, random session id
+    pub fn generate() -> Id {
+        Id(Uuid::new_v4())
+    }
+}
+
+/// A session
+#[derive(Debug, Clone)]
+pub struct Session {
+    /// Unique session identifier
+    pub id: Id,
+    /// The session client
+    pub client: Client,
+    /// When this session expires
+    ///
+    /// The lifetime of a session is inherently tied
+    /// to the expiration of the refresh token issued
+    /// for this session.
+    ///
+    /// Expired sessions should never hit any API method
+    /// since we enforce token expiration validation,
+    /// except for authentication routes.
+    ///
+    /// This is exists so we can actively prune expired
+    /// sessions from memory.
+    pub expires: DateTime<Utc>,
+}
+
+impl Session {
+    /// Returns true if the session is expired from [`SystemTime::now`]
+    pub fn is_expired(&self) -> bool {
+        let start = SystemTime::now();
+        let now = start
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+
+        self.expires.timestamp() as u64 <= now
+    }
+}
+
+/// The client of a [`Session`]
+#[derive(Debug, Clone, PartialEq, Eq, strum::Display)]
+pub enum Client {
+    /// Account client
+    #[strum(serialize = "account(id={account_id}, kind={account_kind}, public_key={public_key})")]
+    Account {
+        /// Account id
+        account_id: account::Id,
+        /// Account kind
+        account_kind: account::Kind,
+        /// Public key of account used for this session
+        public_key: PublicKey,
+    },
+    /// Service client
+    #[strum(serialize = "service(id={service_id}, service={service}, public_key={public_key})")]
+    Service {
+        /// Service id
+        service_id: String,
+        /// Service
+        service: Service,
+        /// Public key of service
+        public_key: PublicKey,
+    },
+}
+
+impl Client {
+    /// The client's [`PublicKey`] for this session
+    pub fn public_key(&self) -> PublicKey {
+        match self {
+            Client::Account { public_key, .. } => *public_key,
+            Client::Service { public_key, .. } => *public_key,
+        }
+    }
+
+    /// The client's [`Role`], if any
+    pub fn role(&self) -> Option<auth::Role> {
+        match self {
+            Client::Account { account_kind, .. } => {
+                matches!(account_kind, account::Kind::Admin).then_some(auth::Role::Admin)
+            }
+            Client::Service { service, .. } => Some(match service {
+                Service::Summit => auth::Role::Hub,
+                Service::Avalanche => auth::Role::Builder,
+                Service::Vessel => auth::Role::RepositoryManager,
+            }),
+        }
+    }
+}
+
+/// A map of active sessions
+#[derive(Debug, Clone, Default)]
+pub struct ActiveSessions(Arc<RwLock<HashMap<Id, Session>>>);
+
+impl ActiveSessions {
+    fn read(&self) -> RwLockReadGuard<'_, HashMap<Id, Session>> {
+        self.0.read().unwrap_or_else(|err| err.into_inner())
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, HashMap<Id, Session>> {
+        self.0.write().unwrap_or_else(|err| err.into_inner())
+    }
+
+    /// Returns the related [`ActiveSession`] if it is still active
+    pub fn get(&self, id: &Id) -> Option<Session> {
+        self.read().get(id).cloned()
+    }
+
+    /// Adds a new [`Session`]
+    pub fn add(&self, session: Session) {
+        self.write().insert(session.id, session);
+    }
+
+    /// Revokes an active session
+    pub fn revoke(&self, id: &Id) {
+        self.write().remove(id);
+    }
+
+    /// Extends an active session
+    pub fn extend(&self, id: &Id, expires: DateTime<Utc>) {
+        if let Some(session) = self.write().get_mut(id) {
+            session.expires = expires;
+        }
+    }
+}

--- a/crates/service-core/src/token.rs
+++ b/crates/service-core/src/token.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 use crate::{
     auth,
     crypto::{self, KeyPair, PublicKey},
+    session,
 };
 
 pub use jsonwebtoken::Header;
@@ -193,6 +194,22 @@ impl Validation {
     }
 }
 
+/// [`Token`] type
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, strum::Display)]
+#[serde(rename_all = "kebab-case", tag = "type")]
+pub enum Kind {
+    /// Token granted to a session
+    #[strum(serialize = "session({session_id})")]
+    Session {
+        /// Session id
+        #[serde(rename = "sid")]
+        session_id: session::Id,
+    },
+    /// Single use token
+    #[strum(serialize = "single-use")]
+    SingleUse,
+}
+
 /// Payload of a [`Token`] which defines various claims
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Payload {
@@ -210,8 +227,9 @@ pub struct Payload {
     /// Permissions granted to the holder
     #[serde(default, rename = "per")]
     pub permissions: HashSet<auth::Permission>,
-    /// The client granted this token
-    pub client: auth::Client,
+    /// The token type & related data
+    #[serde(flatten)]
+    pub kind: Kind,
 }
 
 /// Purpose of the token
@@ -267,8 +285,6 @@ mod test {
     use chrono::{Duration, Utc};
     use jsonwebtoken::Algorithm;
 
-    use crate::{Service, auth};
-
     use super::*;
 
     #[test]
@@ -284,17 +300,10 @@ mod test {
                 exp: one_hour.timestamp(),
                 iat: now.timestamp(),
                 iss: "test".into(),
-                jti: None,
+                jti: Some("foo".into()),
                 purpose: Purpose::Authorization,
                 permissions: Default::default(),
-                client: auth::Client::Service {
-                    service_id: "test".to_owned(),
-                    service: Service::Avalanche,
-                    public_key: "QRpUVLRvtWVfRUTlnen059e5iddhLyStsuzoE8C9yNs"
-                        .to_owned()
-                        .try_into()
-                        .expect("valid public key"),
-                },
+                kind: Kind::SingleUse,
             },
         };
 

--- a/crates/service-grpc/proto/auth.proto
+++ b/crates/service-grpc/proto/auth.proto
@@ -72,6 +72,6 @@ service AuthService {
     option (options.flags) = "NO_AUTH";
   }
   rpc RefreshToken(google.protobuf.Empty) returns (TokenResponse) {
-    option (options.flags) = "BEARER_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_REFRESH";
   }
 }

--- a/crates/service-grpc/proto/summit.proto
+++ b/crates/service-grpc/proto/summit.proto
@@ -100,8 +100,6 @@ message RepositoryManagerStream {
   message RequestUploadToken {
     uint64 task_id = 1;
     repeated common.Collectable collectables = 2;
-    string builder_id = 3;
-    string builder_public_key = 4;
   }
   
   message UploadToken {
@@ -114,36 +112,36 @@ message RepositoryManagerStream {
 service SummitService {
   // Bidirectional stream between summit & builder
   rpc Builder(stream BuilderStream.Incoming) returns (stream BuilderStream.Outgoing) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "ConnectBuilderStream";
   }
 
   // Bidirectional stream between summit & repository manager
   rpc RepositoryManager(stream RepositoryManagerStream.Incoming) returns (stream RepositoryManagerStream.Outgoing) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "ConnectRepositoryManagerStream";
   }
 
   // Commands
 
   rpc Retry(RetryRequest) returns (google.protobuf.Empty) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "RetryTask";
   }
   rpc Cancel(CancelRequest) returns (google.protobuf.Empty) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "CancelTask";
   }
   rpc Refresh(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Refresh";
   }
   rpc Pause(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Pause";
   }
   rpc Resume(google.protobuf.Empty) returns (google.protobuf.Empty) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Resume";
   }
 }

--- a/crates/service-grpc/proto/vessel.proto
+++ b/crates/service-grpc/proto/vessel.proto
@@ -59,26 +59,29 @@ message UpgradeFormatLegacy {
 
 service VesselService {
   rpc Upload(stream UploadRequest) returns (google.protobuf.Empty) {
+    // Single use token / not session scoped
     option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
     option (options.perm) = "UploadPackage";
   }
 
   // Commands
+  // TODO: Move to summit & send them over stream so we can
+  // remove auth service from vessel
   
   rpc UpdateStream(UpdateStreamRequest) returns (CommandResponse) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "UpdateStream";
   }
   rpc AddTag(AddTagRequest) returns (CommandResponse) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "AddTag";
   }
   rpc RemoveTag(RemoveTagRequest) returns (CommandResponse) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "RemoveTag";
   }
   rpc UpgradeFormat(UpgradeFormatRequest) returns (CommandResponse) {
-    option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
+    option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "UpgradeFormat";
   }
 }

--- a/crates/service/migrations/20260702210633_remove-account-token.sql
+++ b/crates/service/migrations/20260702210633_remove-account-token.sql
@@ -1,0 +1,2 @@
+-- Bye bye account_token table
+DROP TABLE IF EXISTS account_token;

--- a/crates/service/src/account.rs
+++ b/crates/service/src/account.rs
@@ -1,6 +1,5 @@
 //! Manage data for admin, user, bot & service accounts
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use thiserror::Error;
@@ -121,68 +120,6 @@ impl Account {
         .await?;
 
         Ok(())
-    }
-}
-
-/// [`Account`] bearer token provisioned for the account after authentication
-#[derive(Debug, Clone, FromRow)]
-pub struct Token {
-    /// Encoded bearer token string
-    pub encoded: String,
-    /// Token expiration time
-    pub expiration: DateTime<Utc>,
-}
-
-impl Token {
-    /// Set the account's bearer token & expiration
-    pub async fn set(
-        tx: &mut database::Transaction,
-        id: Id,
-        encoded: impl ToString,
-        expiration: DateTime<Utc>,
-    ) -> Result<(), Error> {
-        sqlx::query(
-            "
-            INSERT INTO account_token
-            (
-              account_id,
-              encoded,
-              expiration
-            )
-            VALUES (?,?,?)
-            ON CONFLICT(account_id) DO UPDATE SET
-              encoded = excluded.encoded,
-              expiration = excluded.expiration;
-            ",
-        )
-        .bind(id.as_ref())
-        .bind(encoded.to_string())
-        .bind(expiration)
-        .execute(tx.as_mut())
-        .await?;
-
-        Ok(())
-    }
-
-    /// Get the account token for [`Id`] from the provided [`Database`]
-    pub async fn get<'a, T>(conn: &'a mut T, id: Id) -> Result<Token, Error>
-    where
-        &'a mut T: database::Executor<'a>,
-    {
-        let token: Token = sqlx::query_as(
-            "
-            SELECT
-              encoded,
-              expiration
-            FROM account_token
-            WHERE account_id = ?;
-            ",
-        )
-        .bind(id.as_ref())
-        .fetch_one(conn)
-        .await?;
-
-        Ok(token)
     }
 }
 

--- a/crates/service/src/grpc/auth.rs
+++ b/crates/service/src/grpc/auth.rs
@@ -1,5 +1,5 @@
 //! Grpc service enabling authentication
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use base64::Engine;
 use chrono::{DateTime, Utc};
@@ -9,10 +9,11 @@ use futures_util::{
 };
 use rand::Rng;
 use service_core::{
-    Service, Token,
-    auth::{self, AuthorizedService, AuthorizedServices},
+    Service, Session, Token,
+    auth::{self, AuthorizedServices},
     crypto::{self, EncodedPublicKey, EncodedSignature, KeyPair},
-    token::{self, VerifiedToken},
+    session::{self, ActiveSessions},
+    token,
 };
 use service_grpc::proto::auth::{
     AccountCredentials, Credentials, TokenResponse,
@@ -20,7 +21,6 @@ use service_grpc::proto::auth::{
     authenticate_stream, credentials,
 };
 use thiserror::Error;
-use tokio::sync::Mutex;
 use tonic::async_trait;
 use tracing::{debug, info_span};
 use tracing_futures::Instrument;
@@ -40,6 +40,7 @@ pub fn service(
     service: Service,
     db: Database,
     key_pair: KeyPair,
+    active_sessions: ActiveSessions,
     authorized_services: AuthorizedServices,
 ) -> ServiceServer {
     ServiceServer::new(AuthService {
@@ -47,8 +48,8 @@ pub fn service(
             service,
             db,
             key_pair,
+            active_sessions,
             authorized_services,
-            service_bearer_tokens: Default::default(),
         }),
     })
 }
@@ -58,9 +59,8 @@ struct State {
     service: Service,
     db: Database,
     key_pair: KeyPair,
+    active_sessions: ActiveSessions,
     authorized_services: AuthorizedServices,
-    /// Runtime lifetime bearer tokens for authorized services
-    service_bearer_tokens: Mutex<HashMap<AuthorizedService, String>>,
 }
 
 #[async_trait]
@@ -97,7 +97,7 @@ fn authenticate(
         },
         ChallengeSent {
             state: Arc<State>,
-            client: auth::Client,
+            client: session::Client,
             challenge: String,
         },
         Finished,
@@ -144,7 +144,7 @@ fn authenticate(
                                         Error::AccountLookup(username.clone(), encoded_public_key, error)
                                     })?;
 
-                            auth::Client::Account {
+                            session::Client::Account {
                                 account_id: account.id,
                                 account_kind: account.kind,
                                 public_key,
@@ -163,7 +163,7 @@ fn authenticate(
                                 _ => return Err(Error::NonAuthorizedService(service, public_key.encode())),
                             };
 
-                            auth::Client::Service {
+                            session::Client::Service {
                                 service_id: authorized_service.id,
                                 service: authorized_service.service,
                                 public_key,
@@ -220,35 +220,31 @@ fn authenticate(
                         .verify(challenge.as_bytes(), &signature)
                         .map_err(Error::InvalidSignature)?;
 
-                    let (bearer_token, expires_on) =
-                        create_token(&state.key_pair, state.service, &client, token::Purpose::Authorization)?;
-                    let (access_token, _) =
-                        create_token(&state.key_pair, state.service, &client, token::Purpose::Authentication)?;
+                    // Create a new session & provision tokens
+                    let session_id = session::Id::generate();
 
-                    match &client {
-                        auth::Client::Account { account_id, .. } => {
-                            let mut tx = state.db.begin().await?;
+                    let (bearer_token, expires_on) = create_token(
+                        &state.key_pair,
+                        state.service,
+                        session_id,
+                        &client,
+                        token::Purpose::Authorization,
+                    )?;
+                    let (access_token, _) = create_token(
+                        &state.key_pair,
+                        state.service,
+                        session_id,
+                        &client,
+                        token::Purpose::Authentication,
+                    )?;
 
-                            account::Token::set(&mut tx, *account_id, &bearer_token, expires_on)
-                                .await
-                                .map_err(Error::SaveAccountToken)?;
+                    debug!(%client, %session_id, "Authentication successful");
 
-                            tx.commit().await?;
-                        }
-                        auth::Client::Service {
-                            service_id, service, ..
-                        } => {
-                            state.service_bearer_tokens.lock().await.insert(
-                                AuthorizedService {
-                                    id: service_id.clone(),
-                                    service: *service,
-                                },
-                                bearer_token.clone(),
-                            );
-                        }
-                    }
-
-                    debug!(%client, "Authenticate successful");
+                    state.active_sessions.add(Session {
+                        id: session_id,
+                        client,
+                        expires: expires_on,
+                    });
 
                     Ok(Some((
                         authenticate_stream::Outgoing {
@@ -269,77 +265,39 @@ fn authenticate(
 
 #[tracing::instrument(skip_all)]
 async fn refresh_token(state: Arc<State>, request: tonic::Request<()>) -> Result<TokenResponse, Error> {
-    let request_token = request
+    // We've already validated we have non-expired bearer token
+
+    // Assuming we still have a non-revoked active session,
+    // we can safely refresh / extend it
+    let session = request
         .extensions()
-        .get::<VerifiedToken>()
+        .get::<Session>()
         .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+        .ok_or(Error::NoActiveSesssionDuringRefresh)?;
 
-    let client = request_token.decoded.payload.client;
-
-    let bearer_token = match &client {
-        auth::Client::Account { account_id, .. } => {
-            let mut conn = state.db.acquire().await?;
-
-            account::Token::get(conn.as_mut(), *account_id)
-                .await
-                .map_err(Error::ReadAccountToken)?
-                .encoded
-        }
-        auth::Client::Service {
-            service_id, service, ..
-        } => {
-            let service = AuthorizedService {
-                id: service_id.clone(),
-                service: *service,
-            };
-
-            state
-                .service_bearer_tokens
-                .lock()
-                .await
-                .get(&service)
-                .ok_or(Error::NoIssuedServiceBearerToken)?
-                .clone()
-        }
-    };
-
-    if request_token.encoded != bearer_token {
-        return Err(Error::NotCurrentBearerToken);
-    }
-
-    // We've already validated it's not expired in auth middleware
     // Looks good! Let's issue a new pair
 
-    let (bearer_token, expires_on) =
-        create_token(&state.key_pair, state.service, &client, token::Purpose::Authorization)?;
-    let (access_token, _) = create_token(&state.key_pair, state.service, &client, token::Purpose::Authentication)?;
+    let (bearer_token, expires_on) = create_token(
+        &state.key_pair,
+        state.service,
+        session.id,
+        &session.client,
+        token::Purpose::Authorization,
+    )?;
+    let (access_token, _) = create_token(
+        &state.key_pair,
+        state.service,
+        session.id,
+        &session.client,
+        token::Purpose::Authentication,
+    )?;
 
-    match &client {
-        auth::Client::Account { account_id, .. } => {
-            let mut tx = state.db.begin().await?;
-
-            account::Token::set(&mut tx, *account_id, &bearer_token, expires_on)
-                .await
-                .map_err(Error::SaveAccountToken)?;
-
-            tx.commit().await?;
-        }
-        auth::Client::Service {
-            service_id, service, ..
-        } => {
-            state.service_bearer_tokens.lock().await.insert(
-                AuthorizedService {
-                    id: service_id.clone(),
-                    service: *service,
-                },
-                bearer_token.clone(),
-            );
-        }
-    }
+    // Extend the session off the new expiration time
+    state.active_sessions.extend(&session.id, expires_on);
 
     debug!(
-        %client,
+        session_id = %session.id,
+        client = %session.client,
         "Refresh token successful",
     );
 
@@ -352,7 +310,8 @@ async fn refresh_token(state: Arc<State>, request: tonic::Request<()>) -> Result
 fn create_token(
     key_pair: &KeyPair,
     ourself: Service,
-    client: &auth::Client,
+    session_id: session::Id,
+    client: &session::Client,
     purpose: token::Purpose,
 ) -> Result<(String, DateTime<Utc>), Error> {
     let now = Utc::now();
@@ -364,10 +323,10 @@ fn create_token(
         exp: expires_on.timestamp(),
         iat: now.timestamp(),
         iss: ourself.name().to_owned(),
-        client: client.clone(),
         jti: None,
         purpose,
         permissions: auth_role.iter().flat_map(auth::Role::permissions).collect(),
+        kind: token::Kind::Session { session_id },
     })
     .sign(key_pair)
     .map_err(Error::SignToken)?;
@@ -378,15 +337,9 @@ fn create_token(
 /// Auth error
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Service bearer token not issued
-    #[error("Service bearer token not issued")]
-    NoIssuedServiceBearerToken,
-    /// Request token doesn't match current bearer token
-    #[error("Request token doesn't match current bearer token")]
-    NotCurrentBearerToken,
-    /// Token missing from request
-    #[error("Token missing from request")]
-    MissingRequestToken,
+    /// No active session found during token refresh
+    #[error("No active session found during token refresh")]
+    NoActiveSesssionDuringRefresh,
     /// Malformed request
     #[error("Malformed request")]
     MalformedRequest,
@@ -428,13 +381,11 @@ pub enum Error {
 impl From<Error> for tonic::Status {
     fn from(error: Error) -> Self {
         match error {
-            Error::InvalidSignature(_)
+            Error::NoActiveSesssionDuringRefresh
+            | Error::InvalidSignature(_)
             | Error::AccountLookup(..)
-            | Error::NoIssuedServiceBearerToken
-            | Error::NotCurrentBearerToken
             | Error::NonAuthorizedService(..) => tonic::Status::unauthenticated(""),
-            Error::MissingRequestToken
-            | Error::MalformedRequest
+            Error::MalformedRequest
             | Error::SignToken(_)
             | Error::SaveAccountToken(_)
             | Error::ReadAccountToken(_)

--- a/crates/service/src/lib.rs
+++ b/crates/service/src/lib.rs
@@ -2,7 +2,7 @@
 //! Shared service code for AerynOS infrastructure
 
 pub use service_client as client;
-pub use service_core::{Service, Token, auth, crypto, token};
+pub use service_core::{Service, Session, Token, auth, crypto, session, token};
 
 pub use self::account::Account;
 pub use self::database::Database;

--- a/crates/service/src/middleware.rs
+++ b/crates/service/src/middleware.rs
@@ -2,10 +2,12 @@
 //!
 //! [`Server`]: crate::Server
 
+pub use self::extract_active_session::ExtractActiveSession;
 pub use self::extract_token::ExtractToken;
 pub use self::grpc_method::GrpcMethod;
 pub use self::log::Log;
 
+pub mod extract_active_session;
 pub mod extract_token;
 pub mod grpc_method;
 pub mod log;

--- a/crates/service/src/middleware/extract_active_session.rs
+++ b/crates/service/src/middleware/extract_active_session.rs
@@ -1,0 +1,75 @@
+//! Active session lookup middleware
+
+use service_core::{
+    auth,
+    session::ActiveSessions,
+    token::{self, VerifiedToken},
+};
+
+/// Checks the incoming session to see if it is still active and
+/// if so, inserts it as a request extension.
+///
+/// Must be layered after the [`ExtractToken`] layer so session
+/// can be identified from the valid token.
+///
+/// [`ExtractToken`]: super::ExtractToken
+#[derive(Debug, Clone)]
+pub struct ExtractActiveSession {
+    /// In-memory map of active sessions
+    pub active_sessions: ActiveSessions,
+}
+
+impl<S> tower::Layer<S> for ExtractActiveSession {
+    type Service = Service<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Service {
+            inner,
+            active_sessions: self.active_sessions.clone(),
+        }
+    }
+}
+
+/// Tower service of the [`ExtractActiveSession`] layer
+#[derive(Debug, Clone)]
+pub struct Service<S> {
+    inner: S,
+    active_sessions: ActiveSessions,
+}
+
+impl<S, ReqBody, ResBody> tower::Service<http::Request<ReqBody>> for Service<S>
+where
+    S: tower::Service<http::Request<ReqBody>, Response = http::Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
+        tower::Service::poll_ready(&mut self.inner, cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqBody>) -> Self::Future {
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        if let Some(token) = req.extensions().get::<VerifiedToken>()
+            && let token::Kind::Session { session_id } = token.decoded.payload.kind
+            && let Some(session) = self.active_sessions.get(&session_id)
+        {
+            // TODO: Add background job to clean these up automatically
+            if session.is_expired() {
+                self.active_sessions.revoke(&session.id);
+            } else {
+                if let Some(flags) = req.extensions_mut().get_mut::<auth::Flags>() {
+                    *flags |= auth::Flags::VALID_SESSION;
+                }
+
+                req.extensions_mut().insert(session);
+            }
+        };
+
+        inner.call(req)
+    }
+}

--- a/crates/service/src/middleware/extract_token.rs
+++ b/crates/service/src/middleware/extract_token.rs
@@ -86,9 +86,9 @@ where
 
             let token_flags = flag_names(flags);
             let token_purpose = Some(token.decoded.payload.purpose.to_string());
-            let client = &token.decoded.payload.client;
+            let token_type = &token.decoded.payload.kind;
 
-            debug!(?token_flags, token_purpose, ?permissions, %client, "Auth parsed");
+            debug!(?token_flags, token_purpose, %token_type, ?permissions, "Auth parsed");
         }
 
         req.extensions_mut().insert(flags);

--- a/crates/service/src/server.rs
+++ b/crates/service/src/server.rs
@@ -124,6 +124,10 @@ impl Server<'_> {
         if let Some(addr) = self.http_addr {
             let router = self
                 .http_router
+                // Layers are defined inner -> outer
+                .layer(middleware::ExtractActiveSession {
+                    active_sessions: self.state.active_sessions.clone(),
+                })
                 .layer(self.extract_token.clone())
                 .layer(middleware::Log);
 
@@ -143,9 +147,13 @@ impl Server<'_> {
                 // https://grpc.io/docs/guides/keepalive/#keepalive-configuration-specification
                 .http2_keepalive_interval(Some(Duration::from_secs(60 * 60 * 2)))
                 .http2_keepalive_timeout(Some(Duration::from_secs(20)))
+                // Layers are defined outer to inner (reverse from axum router)
                 .layer(middleware::Log)
                 .layer(middleware::GrpcMethod)
                 .layer(self.extract_token)
+                .layer(middleware::ExtractActiveSession {
+                    active_sessions: self.state.active_sessions.clone(),
+                })
                 .add_routes(self.grpc_router);
 
             runner = runner.with_task("grpc server", async move {

--- a/crates/service/src/state.rs
+++ b/crates/service/src/state.rs
@@ -4,6 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use service_core::session::ActiveSessions;
 use thiserror::Error;
 use tokio::fs;
 use tracing::debug;
@@ -29,6 +30,8 @@ pub struct State {
     pub service_db: Database,
     /// Key pair used by the service
     pub key_pair: KeyPair,
+    /// Active sessions, if auth service is enabled
+    pub active_sessions: ActiveSessions,
 }
 
 impl State {
@@ -75,6 +78,7 @@ impl State {
             db_dir,
             service_db,
             key_pair,
+            active_sessions: ActiveSessions::default(),
         })
     }
 

--- a/crates/summit/src/grpc.rs
+++ b/crates/summit/src/grpc.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use http::Extensions;
 use service::{
-    Service, auth,
+    Service, Session,
     crypto::PublicKey,
     grpc::{
         self,
@@ -13,7 +13,7 @@ use service::{
             summit_service_server::{SummitService as GrpcSummitService, SummitServiceServer},
         },
     },
-    token::VerifiedToken,
+    session,
 };
 use snafu::{ResultExt, Snafu};
 use tokio::{
@@ -119,14 +119,11 @@ impl GrpcSummitService for SummitService {
     )
 )]
 async fn retry(state: Arc<State>, request: tonic::Request<RetryRequest>) -> Result<(), Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Retry task"
     );
 
@@ -144,14 +141,11 @@ async fn retry(state: Arc<State>, request: tonic::Request<RetryRequest>) -> Resu
     )
 )]
 async fn cancel(state: Arc<State>, request: tonic::Request<CancelRequest>) -> Result<(), Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Cancel task"
     );
 
@@ -164,14 +158,11 @@ async fn cancel(state: Arc<State>, request: tonic::Request<CancelRequest>) -> Re
 
 #[tracing::instrument(skip_all)]
 async fn refresh(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Refresh"
     );
 
@@ -182,14 +173,11 @@ async fn refresh(state: Arc<State>, request: tonic::Request<()>) -> Result<(), E
 
 #[tracing::instrument(skip_all)]
 async fn pause(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Pause"
     );
 
@@ -200,14 +188,11 @@ async fn pause(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Err
 
 #[tracing::instrument(skip_all)]
 async fn resume(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Resume"
     );
 
@@ -225,18 +210,15 @@ async fn builder(
 ) -> Result<(), Error> {
     let span = Span::current();
 
-    let token = extensions
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = extensions.get::<Session>().cloned().ok_or(Error::NoActiveSession)?;
 
-    let (builder_id, public_key) = match token.decoded.payload.client {
-        auth::Client::Service {
+    let (builder_id, public_key) = match session.client {
+        session::Client::Service {
             service_id: id,
             public_key,
             service: Service::Avalanche,
         } => (id, public_key),
-        client => return Err(Error::InvalidTokenClient { client }),
+        client => return Err(Error::InvalidSessionClient { client }),
     };
 
     // Verify this is an actively configured builder. This will reject
@@ -384,18 +366,15 @@ async fn repository_manager(
 ) -> Result<(), Error> {
     let span = Span::current();
 
-    let token = extensions
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = extensions.get::<Session>().cloned().ok_or(Error::NoActiveSession)?;
 
-    let (repository_manager_id, public_key) = match token.decoded.payload.client {
-        auth::Client::Service {
+    let (repository_manager_id, public_key) = match session.client {
+        session::Client::Service {
             service_id: id,
             public_key,
             service: Service::Vessel,
         } => (id, public_key),
-        client => return Err(Error::InvalidTokenClient { client }),
+        client => return Err(Error::InvalidSessionClient { client }),
     };
 
     // Verify this is the actively configured repo manager. This will reject
@@ -484,10 +463,10 @@ async fn repository_manager(
 
 #[derive(Debug, Snafu)]
 enum Error {
-    #[snafu(display("Token missing from request"))]
-    MissingRequestToken,
-    #[snafu(display("Invalid token client: {client}"))]
-    InvalidTokenClient { client: auth::Client },
+    #[snafu(display("No active session"))]
+    NoActiveSession,
+    #[snafu(display("Invalid session client: {client}"))]
+    InvalidSessionClient { client: session::Client },
     #[snafu(display("Unconfigured builder {builder_id} with public key {public_key}"))]
     UnconfiguredBuilder { builder_id: String, public_key: PublicKey },
     #[snafu(display("Unconfigured repository manager {repository_manager_id} with public key {public_key}"))]
@@ -512,10 +491,10 @@ enum Error {
 impl From<Error> for tonic::Status {
     fn from(error: Error) -> Self {
         match error {
-            Error::MissingRequestToken
-            | Error::InvalidTokenClient { .. }
+            Error::NoActiveSession
             | Error::UnconfiguredBuilder { .. }
             | Error::UnconfiguredRepositoryManager { .. } => tonic::Status::unauthenticated(""),
+            Error::InvalidSessionClient { .. } => tonic::Status::permission_denied(""),
             Error::BuilderStream { source } => source,
             Error::CreateLogFile { .. }
             | Error::WriteLogFile { .. }

--- a/crates/summit/src/main.rs
+++ b/crates/summit/src/main.rs
@@ -121,6 +121,7 @@ async fn main() -> Result<()> {
                     SERVICE,
                     state.service_db().clone(),
                     state.service.key_pair.clone(),
+                    state.service.active_sessions.clone(),
                     authorized_services,
                 ))
                 .add_service(grpc::summit_service(&state, config, worker_sender));

--- a/crates/summit/src/manager.rs
+++ b/crates/summit/src/manager.rs
@@ -609,7 +609,7 @@ impl Manager {
 
                     if let Err(err) = self
                         .repository_manager
-                        .request_upload_token(task_id, collectables, builder)
+                        .request_upload_token(task_id, collectables)
                         .await
                     {
                         error!(

--- a/crates/summit/src/repository_manager.rs
+++ b/crates/summit/src/repository_manager.rs
@@ -8,7 +8,7 @@ use service::{
 use tokio::sync::mpsc;
 use tracing::{error, info};
 
-use crate::{Builder, task};
+use crate::task;
 
 #[derive(Debug)]
 pub enum Message {
@@ -69,13 +69,8 @@ impl RepositoryManager {
         }
     }
 
-    #[tracing::instrument(skip_all, fields(%task_id, builder = builder.config.id))]
-    pub async fn request_upload_token(
-        &self,
-        task_id: task::Id,
-        collectables: Vec<Collectable>,
-        builder: &Builder,
-    ) -> Result<()> {
+    #[tracing::instrument(skip_all, fields(%task_id))]
+    pub async fn request_upload_token(&self, task_id: task::Id, collectables: Vec<Collectable>) -> Result<()> {
         let connection = self
             .connection
             .as_ref()
@@ -89,8 +84,6 @@ impl RepositoryManager {
                     repository_manager_stream::RequestUploadToken {
                         task_id: i64::from(task_id) as u64,
                         collectables,
-                        builder_id: builder.config.id.clone(),
-                        builder_public_key: builder.config.public_key.to_string(),
                     },
                 )),
             })

--- a/crates/vessel/src/grpc.rs
+++ b/crates/vessel/src/grpc.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::{OptionExt as _, Report, bail, eyre};
 use futures_util::TryStreamExt;
 use prost::Message;
 use service::{
-    Service, crypto,
+    Session,
     grpc::{
         self,
         proto::{
@@ -28,6 +28,8 @@ use crate::{
     channel::{self, FormatUpgrade},
     upload, worker,
 };
+
+pub use service::grpc::auth::service as auth_service;
 
 pub fn vessel_service(state: service::State, worker: worker::Sender) -> VesselServiceServer<VesselService> {
     VesselServiceServer::new(VesselService {
@@ -94,7 +96,7 @@ impl GrpcVesselService for VesselService {
     }
 }
 
-#[tracing::instrument(skip_all, fields(task_id, builder_id))]
+#[tracing::instrument(skip_all, fields(task_id))]
 async fn upload(state: Arc<State>, request: tonic::Request<tonic::Streaming<UploadRequest>>) -> Result<(), Error> {
     let token = request
         .extensions()
@@ -108,14 +110,6 @@ async fn upload(state: Arc<State>, request: tonic::Request<tonic::Streaming<Uplo
     // so we can validate this token matches & we can see what
     // collectables will be uploaded
     let header_chunk = stream.try_next().await?.context(MissingUploadTokenRequestSnafu)?.chunk;
-    // Second chunk is a signature over the first chunk using the declared builders
-    // public key signing key. This is used to confirm the upload token granted for this upload
-    // is actually used by the builder to make this request.
-    let signature_chunk = stream
-        .try_next()
-        .await?
-        .context(MissingUploadSignatureRequestSnafu)?
-        .chunk;
 
     let header = BuildFinished::decode(&*header_chunk).context(DecodeUploadTokenRequestSnafu)?;
 
@@ -126,29 +120,6 @@ async fn upload(state: Arc<State>, request: tonic::Request<tonic::Streaming<Uplo
 
     if token.decoded.payload.jti.is_none_or(|h| h != hash) {
         return Err(Error::InvalidUploadToken);
-    }
-
-    // Validate this request came from the authenticated builder
-    //
-    // This token isn't directly granted to the builder, but is more of a
-    // "step-up" token passed to the builder via summit. This is a sanity
-    // check that summit or something else isn't using the token and its
-    // the intended builder.
-    match token.decoded.payload.client {
-        service::auth::Client::Service {
-            service_id: builder_id,
-            service: Service::Avalanche,
-            public_key: builder_public_key,
-        } => {
-            let signature = crypto::signature_from_bytes(&signature_chunk).context(ParseUploadSignatureSnafu)?;
-
-            builder_public_key
-                .verify(&header_chunk, &signature)
-                .context(UploadSignatureVerificationSnafu)?;
-
-            span.record("builder_id", builder_id);
-        }
-        _ => return Err(Error::InvalidUploadToken),
     }
 
     info!(num_packages = header.collectables.len(), "Upload requested");
@@ -187,14 +158,11 @@ async fn update_stream(
     state: Arc<State>,
     request: tonic::Request<UpdateStreamRequest>,
 ) -> Result<CommandResponse, Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Update stream request received"
     );
 
@@ -251,14 +219,11 @@ async fn update_stream(
     )
 )]
 async fn add_tag(state: Arc<State>, request: tonic::Request<AddTagRequest>) -> Result<CommandResponse, Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Add tag request received"
     );
 
@@ -309,14 +274,11 @@ async fn add_tag(state: Arc<State>, request: tonic::Request<AddTagRequest>) -> R
     )
 )]
 async fn remove_tag(state: Arc<State>, request: tonic::Request<RemoveTagRequest>) -> Result<CommandResponse, Error> {
-    let token = request
-        .extensions()
-        .get::<VerifiedToken>()
-        .cloned()
-        .ok_or(Error::MissingRequestToken)?;
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
-        client = %token.decoded.payload.client,
+        session_id = %session.id,
+        client = %session.client,
         "Remove tag request received"
     );
 
@@ -429,6 +391,8 @@ async fn upgrade_format(
 enum Error {
     #[snafu(display("Token missing from request"))]
     MissingRequestToken,
+    #[snafu(display("No active session"))]
+    NoActiveSession,
     #[snafu(display("Invalid upload token"))]
     InvalidUploadToken,
     #[snafu(display("Failed to send task to worker"))]
@@ -447,22 +411,16 @@ enum Error {
     OneshotRecv { source: oneshot::error::RecvError },
     #[snafu(display("Failed to save packages"))]
     SavePackages { source: upload::Error },
-    #[snafu(display("Failed to parse upload signature"))]
-    ParseUploadSignature { source: crypto::Error },
-    #[snafu(display("Upload signature verification failed"))]
-    UploadSignatureVerification { source: crypto::Error },
 }
 
 impl From<Error> for tonic::Status {
     fn from(error: Error) -> Self {
         match error {
-            Error::MissingRequestToken => tonic::Status::unauthenticated(""),
+            Error::MissingRequestToken | Error::NoActiveSession => tonic::Status::unauthenticated(""),
             Error::InvalidUploadToken => tonic::Status::permission_denied(""),
             Error::MissingUploadTokenRequest
             | Error::MissingUploadSignatureRequest
-            | Error::DecodeUploadTokenRequest { .. }
-            | Error::ParseUploadSignature { .. }
-            | Error::UploadSignatureVerification { .. } => tonic::Status::invalid_argument(""),
+            | Error::DecodeUploadTokenRequest { .. } => tonic::Status::invalid_argument(""),
             Error::SendWorker { .. } | Error::OneshotRecv { .. } => tonic::Status::internal(""),
             Error::GrpcRequest { source } => source,
             Error::SavePackages { source } => match source {
@@ -470,7 +428,6 @@ impl From<Error> for tonic::Status {
                 | upload::Error::InvalidSha256Length { .. }
                 | upload::Error::InvalidCollectableKind { .. } => tonic::Status::invalid_argument(""),
                 upload::Error::SignUploadToken { .. }
-                | upload::Error::ParseBuilderPublicKey { .. }
                 | upload::Error::CreateDownloadDir { .. }
                 | upload::Error::WriteDownloadFile { .. }
                 | upload::Error::UnexpectedEndOfUpload

--- a/crates/vessel/src/main.rs
+++ b/crates/vessel/src/main.rs
@@ -3,6 +3,7 @@ use std::{net::IpAddr, path::PathBuf};
 use channel::DEFAULT_CHANNEL;
 use clap::Parser;
 use color_eyre::eyre::Context;
+use service::auth::AuthorizedServices;
 use service::{Server, Service, buildinfo, error};
 use tracing::{error, info};
 
@@ -19,6 +20,8 @@ mod state;
 mod stream;
 mod upload;
 mod worker;
+
+pub const SERVICE: Service = Service::Vessel;
 
 pub type Result<T, E = color_eyre::eyre::Error> = std::result::Result<T, E>;
 
@@ -66,11 +69,23 @@ async fn main() -> Result<()> {
 
     let (worker_sender, worker_events, worker_task) = worker::run(state.clone()).await?;
 
-    Server::new(Service::Vessel, &state.service, config.admin.clone())
+    Server::new(SERVICE, &state.service, config.admin.clone())
         .with_task("worker", worker_task)
         .with_task("stream", stream::run(state.clone(), config.clone(), worker_events))
         .with_grpc((host, grpc_port), |routes| {
-            routes.add_service(grpc::vessel_service(state.service.clone(), worker_sender));
+            routes
+                .add_service(grpc::auth_service(
+                    SERVICE,
+                    state.service_db().clone(),
+                    state.service.key_pair.clone(),
+                    state.service.active_sessions.clone(),
+                    // No services auth w/ vessel, only admin accounts
+                    //
+                    // TODO: route all vessel commands via
+                    // summit -> stream
+                    AuthorizedServices::default(),
+                ))
+                .add_service(grpc::vessel_service(state.service.clone(), worker_sender));
         })
         .start()
         .await?;

--- a/crates/vessel/src/stream.rs
+++ b/crates/vessel/src/stream.rs
@@ -136,8 +136,7 @@ async fn connect_inner(
 
                             info!(
                                 task_id = request.task_id,
-                                builder_id = request.builder_id,
-                                "Upload token issued for builder"
+                                "Upload token issued for task"
                             );
                         },
                     }

--- a/crates/vessel/src/upload.rs
+++ b/crates/vessel/src/upload.rs
@@ -6,7 +6,7 @@ use std::{
 use chrono::Utc;
 use futures_util::{Stream, TryStreamExt};
 use service::{
-    Service, Token, auth, crypto,
+    Service, Token, auth,
     grpc::proto::{
         common::{Collectable, collectable},
         summit::{builder_stream::BuildFinished, repository_manager_stream::RequestUploadToken},
@@ -42,15 +42,7 @@ pub fn upload_token(state: &State, request: &RequestUploadToken) -> Result<Strin
         jti: Some(hash),
         permissions: [auth::Permission::UploadPackage].into_iter().collect(),
         iss: Service::Vessel.name().to_owned(),
-        client: auth::Client::Service {
-            service_id: request.builder_id.clone(),
-            service: Service::Avalanche,
-            public_key: request
-                .builder_public_key
-                .clone()
-                .try_into()
-                .context(ParseBuilderPublicKeySnafu)?,
-        },
+        kind: token::Kind::SingleUse,
         purpose: token::Purpose::Authentication,
     })
     .sign(&state.service.key_pair)
@@ -158,8 +150,6 @@ async fn download_path(state_dir: &Path, hash: &str) -> Result<PathBuf, Error> {
 pub enum Error {
     #[snafu(display("Failed to sign upload token"))]
     SignUploadToken { source: token::Error },
-    #[snafu(display("Failed to parse builder public key"))]
-    ParseBuilderPublicKey { source: crypto::Error },
     #[snafu(display("Cannot import collectable type {kind:?}"))]
     InvalidCollectableKind { kind: collectable::Kind },
     #[snafu(display("Failed to create download directory"))]


### PR DESCRIPTION
This adds a new "session" concept that our auth is now tied to. This is in preparation to us adding an admin dashboard and needing to track "sessions".

The current data model assumes a single bearer token is granted to an account but this won't work across multiple logins / sessions. We instead need to track many sessions per account.

I drop the `account_token` table because this model is no longer valid and token refresh is now tied to the session being active / valid. This will also enable us to "revoke" sessions and invalidate all JWTs tied to that session_id. We currently store all sessions in memory so lookup after token validation is cheap, but this does mean a service restart drops all active sessions -> requires re-auth. This is fine for now, we can look into session persistence once we actually get around to adding the admin dashboard / having user accounts. 