### PR TITLE
Migrate vessel commands over summit stream

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,13 +3,12 @@ use std::{path::PathBuf, process};
 use clap::{Parser, Subcommand, ValueEnum};
 use color_eyre::eyre::{Result, bail};
 use moss::repository::Format;
-use service_client::{AuthClient, Credentials, CredentialsAuth, SummitServiceClient, TlsConfig, VesselServiceClient};
+use service_client::{AuthClient, Credentials, CredentialsAuth, SummitServiceClient, TlsConfig};
 use service_core::crypto::KeyPair;
 use service_grpc::{
-    proto::summit::{CancelRequest, RetryRequest},
+    proto::summit::command,
     proto::vessel::{
-        AddTagRequest, RemoveTagRequest, Stream as ProtoStream, UpdateStreamRequest, UpgradeFormat,
-        UpgradeFormatLegacy, UpgradeFormatRequest, upgrade_format,
+        Stream as ProtoStream, UpgradeFormat, UpgradeFormatLegacy, command as vessel_command, upgrade_format,
     },
 };
 use tokio::{fs, io};
@@ -43,55 +42,19 @@ async fn main() -> Result<()> {
             )
             .await?;
 
-            match command {
-                Summit::Retry { task } => {
-                    client.retry(RetryRequest { task_id: task }).await?;
-                }
-                Summit::Cancel { task } => {
-                    client.cancel(CancelRequest { task_id: task }).await?;
-                }
-                Summit::Refresh {} => {
-                    client.refresh(()).await?;
-                }
-                Summit::Pause {} => {
-                    client.pause(()).await?;
-                }
-                Summit::Resume {} => {
-                    client.resume(()).await?;
-                }
-            }
-        }
-        Command::Vessel {
-            uri,
-            username,
-            private_key,
-            ca_cert,
-            command,
-        } => {
-            let key_pair = KeyPair::load(private_key)?;
-
-            println!("Using key_pair {}", key_pair.public_key().encode());
-
-            let tls = ca_cert.map(|ca_cert| TlsConfig {
-                ca: Some(ca_cert),
-                ..Default::default()
-            });
-
-            let mut client = VesselServiceClient::connect_with_auth(
-                uri,
-                tls,
-                CredentialsAuth::with_in_memory_storage(Credentials::Account { username, key_pair }),
-            )
-            .await?;
-
             let response = match command {
-                Vessel::UpdateStream {
+                Summit::Retry { task } => client.retry(command::Retry { task_id: task }).await?,
+                Summit::Cancel { task } => client.cancel(command::Cancel { task_id: task }).await?,
+                Summit::Refresh {} => client.refresh(()).await?,
+                Summit::Pause {} => client.pause(()).await?,
+                Summit::Resume {} => client.resume(()).await?,
+                Summit::UpdateStream {
                     channel,
                     stream,
                     version,
                 } => {
                     client
-                        .update_stream(UpdateStreamRequest {
+                        .update_stream(vessel_command::UpdateStream {
                             channel,
                             stream: match stream {
                                 ChannelStream::Volatile => ProtoStream::Volatile,
@@ -101,11 +64,13 @@ async fn main() -> Result<()> {
                         })
                         .await?
                 }
-                Vessel::AddTag { channel, tag, history } => {
-                    client.add_tag(AddTagRequest { channel, tag, history }).await?
+                Summit::AddTag { channel, tag, history } => {
+                    client.add_tag(vessel_command::AddTag { channel, tag, history }).await?
                 }
-                Vessel::RemoveTag { channel, tag } => client.remove_tag(RemoveTagRequest { channel, tag }).await?,
-                Vessel::UpgradeFormat { channel, format, tag } => {
+                Summit::RemoveTag { channel, tag } => {
+                    client.remove_tag(vessel_command::RemoveTag { channel, tag }).await?
+                }
+                Summit::UpgradeFormat { channel, format, tag } => {
                     let format = Format::from(format.as_str());
 
                     let upgrade_format = match format {
@@ -117,7 +82,7 @@ async fn main() -> Result<()> {
                     };
 
                     client
-                        .upgrade_format(UpgradeFormatRequest {
+                        .upgrade_format(vessel_command::FormatUpgrade {
                             channel,
                             format: Some(upgrade_format),
                         })
@@ -181,6 +146,7 @@ struct Args {
 }
 
 #[derive(Debug, Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Command {
     /// Summit commands
     Summit {
@@ -198,23 +164,6 @@ enum Command {
         ca_cert: Option<PathBuf>,
         #[command(subcommand)]
         command: Summit,
-    },
-    /// Vessel commands
-    Vessel {
-        /// Uri to connect to
-        #[arg(long = "uri", default_value = "http://127.0.0.1:5002")]
-        uri: Uri,
-        /// Admin username
-        #[arg(long = "user")]
-        username: String,
-        /// Path to admin private key
-        #[arg(long = "key")]
-        private_key: PathBuf,
-        /// Path to a PEM ca cert
-        #[arg(long)]
-        ca_cert: Option<PathBuf>,
-        #[command(subcommand)]
-        command: Vessel,
     },
     /// Work with ed25519 keys
     Key {
@@ -241,10 +190,6 @@ enum Summit {
     Pause {},
     /// Resume all projects
     Resume {},
-}
-
-#[derive(Debug, Subcommand)]
-enum Vessel {
     /// Update a stream to link to a new version
     UpdateStream {
         /// Channel name

--- a/crates/service-grpc/proto/summit.proto
+++ b/crates/service-grpc/proto/summit.proto
@@ -4,15 +4,8 @@ package summit;
 
 import "common.proto";
 import "options.proto";
+import "vessel.proto";
 import "google/protobuf/empty.proto";
-
-message RetryRequest {
-  uint64 task_id = 1;
-}
-
-message CancelRequest {
-  uint64 task_id = 1;
-}
 
 message BuilderStream {
   message Incoming {
@@ -84,12 +77,14 @@ message RepositoryManagerStream {
       UploadToken upload_token = 2;
       uint64 import_succeeded = 3;
       uint64 import_failed = 4;
+      vessel.Command.Response command = 5;
     }
   }
 
   message Outgoing {
     oneof event {
       RequestUploadToken request_upload_token = 1;
+      vessel.Command.Request command = 2;
     }
   }
 
@@ -109,6 +104,21 @@ message RepositoryManagerStream {
   }
 }
 
+message Command {
+  message Retry {
+    uint64 task_id = 1;
+  }
+  
+  message Cancel {
+    uint64 task_id = 1;
+  }
+
+  message Response {
+    bool success = 1;
+    optional string error = 2;
+  }
+}
+
 service SummitService {
   // Bidirectional stream between summit & builder
   rpc Builder(stream BuilderStream.Incoming) returns (stream BuilderStream.Outgoing) {
@@ -123,25 +133,40 @@ service SummitService {
   }
 
   // Commands
-
-  rpc Retry(RetryRequest) returns (google.protobuf.Empty) {
+  rpc Retry(Command.Retry) returns (Command.Response) {
     option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "RetryTask";
   }
-  rpc Cancel(CancelRequest) returns (google.protobuf.Empty) {
+  rpc Cancel(Command.Cancel) returns (Command.Response) {
     option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "CancelTask";
   }
-  rpc Refresh(google.protobuf.Empty) returns (google.protobuf.Empty) {
+  rpc Refresh(google.protobuf.Empty) returns (Command.Response) {
     option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Refresh";
   }
-  rpc Pause(google.protobuf.Empty) returns (google.protobuf.Empty) {
+  rpc Pause(google.protobuf.Empty) returns (Command.Response) {
     option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Pause";
   }
-  rpc Resume(google.protobuf.Empty) returns (google.protobuf.Empty) {
+  rpc Resume(google.protobuf.Empty) returns (Command.Response) {
     option (options.flags) = "SESSION_ACCESS";
     option (options.perm) = "Resume";
+  }
+  rpc UpdateStream(vessel.Command.UpdateStream) returns (Command.Response) {
+    option (options.flags) = "SESSION_ACCESS";
+    option (options.perm) = "UpdateStream";
+  }
+  rpc AddTag(vessel.Command.AddTag) returns (Command.Response) {
+    option (options.flags) = "SESSION_ACCESS";
+    option (options.perm) = "AddTag";
+  }
+  rpc RemoveTag(vessel.Command.RemoveTag) returns (Command.Response) {
+    option (options.flags) = "SESSION_ACCESS";
+    option (options.perm) = "RemoveTag";
+  }
+  rpc UpgradeFormat(vessel.Command.FormatUpgrade) returns (Command.Response) {
+    option (options.flags) = "SESSION_ACCESS";
+    option (options.perm) = "UpgradeFormat";
   }
 }

--- a/crates/service-grpc/proto/vessel.proto
+++ b/crates/service-grpc/proto/vessel.proto
@@ -9,38 +9,54 @@ message UploadRequest {
   bytes chunk = 1;
 }
 
-message UpdateStreamRequest {
-  string channel = 1;
-  Stream stream = 2;
-  string version = 3;
-}
-
-message AddTagRequest {
-  string channel = 1;
-  string tag = 2;
-  string history = 3;
-}
-
-message RemoveTagRequest {
-  string channel = 1;
-  string tag = 2;
-}
-
 enum Stream {
   STREAM_UNKNOWN = 0;
   STREAM_VOLATILE = 1;
   STREAM_UNSTABLE = 2;
 }
 
-message CommandResponse {
-  bool success = 1;
-  optional string error = 2;
-}
+message Command {
+  message Request {
+    string request_id = 1;
+    Inner command = 2;
+  }
 
-message UpgradeFormatRequest {
-  string channel = 1;
-  UpgradeFormat format = 2;
+  message Response {
+    string request_id = 1;
+    bool success = 2;
+    optional string error = 3;
+  }
 
+  message Inner {
+    oneof command {
+      vessel.Command.UpdateStream update_stream = 1;
+      vessel.Command.AddTag add_tag = 2;
+      vessel.Command.RemoveTag remove_tag = 3;
+      vessel.Command.FormatUpgrade upgrade_format = 4;
+    }
+  }
+
+  message UpdateStream {
+    string channel = 1;
+    Stream stream = 2;
+    string version = 3;
+  }
+  
+  message AddTag {
+    string channel = 1;
+    string tag = 2;
+    string history = 3;
+  }
+  
+  message RemoveTag {
+    string channel = 1;
+    string tag = 2;
+  }
+  
+  message FormatUpgrade {
+    string channel = 1;
+    UpgradeFormat format = 2;
+  }
 }
 
 message UpgradeFormat {
@@ -62,26 +78,5 @@ service VesselService {
     // Single use token / not session scoped
     option (options.flags) = "ACCESS_TOKEN | NOT_EXPIRED";
     option (options.perm) = "UploadPackage";
-  }
-
-  // Commands
-  // TODO: Move to summit & send them over stream so we can
-  // remove auth service from vessel
-  
-  rpc UpdateStream(UpdateStreamRequest) returns (CommandResponse) {
-    option (options.flags) = "SESSION_ACCESS";
-    option (options.perm) = "UpdateStream";
-  }
-  rpc AddTag(AddTagRequest) returns (CommandResponse) {
-    option (options.flags) = "SESSION_ACCESS";
-    option (options.perm) = "AddTag";
-  }
-  rpc RemoveTag(RemoveTagRequest) returns (CommandResponse) {
-    option (options.flags) = "SESSION_ACCESS";
-    option (options.perm) = "RemoveTag";
-  }
-  rpc UpgradeFormat(UpgradeFormatRequest) returns (CommandResponse) {
-    option (options.flags) = "SESSION_ACCESS";
-    option (options.perm) = "UpgradeFormat";
   }
 }

--- a/crates/summit/src/grpc.rs
+++ b/crates/summit/src/grpc.rs
@@ -8,9 +8,12 @@ use service::{
     crypto::PublicKey,
     grpc::{
         self,
-        proto::summit::{
-            CancelRequest, RetryRequest, builder_stream, repository_manager_stream,
-            summit_service_server::{SummitService as GrpcSummitService, SummitServiceServer},
+        proto::{
+            summit::{
+                builder_stream, command, repository_manager_stream,
+                summit_service_server::{SummitService as GrpcSummitService, SummitServiceServer},
+            },
+            vessel::command::{self as vessel_command, inner::Command as VesselCommand},
         },
     },
     session,
@@ -19,7 +22,7 @@ use snafu::{ResultExt, Snafu};
 use tokio::{
     fs::{self, File},
     io::AsyncWriteExt,
-    sync::mpsc,
+    sync::{mpsc, oneshot},
 };
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tracing::{Instrument, Span, info};
@@ -59,34 +62,76 @@ impl GrpcSummitService for SummitService {
     type BuilderStream = ReceiverStream<Result<builder_stream::Outgoing, tonic::Status>>;
     type RepositoryManagerStream = ReceiverStream<Result<repository_manager_stream::Outgoing, tonic::Status>>;
 
-    async fn retry(&self, request: tonic::Request<RetryRequest>) -> Result<tonic::Response<()>, tonic::Status> {
+    async fn retry(
+        &self,
+        request: tonic::Request<command::Retry>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| retry(state, request).await).await
     }
 
-    async fn cancel(&self, request: tonic::Request<CancelRequest>) -> Result<tonic::Response<()>, tonic::Status> {
+    async fn cancel(
+        &self,
+        request: tonic::Request<command::Cancel>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| cancel(state, request).await).await
     }
 
-    async fn refresh(&self, request: tonic::Request<()>) -> Result<tonic::Response<()>, tonic::Status> {
+    async fn refresh(&self, request: tonic::Request<()>) -> Result<tonic::Response<command::Response>, tonic::Status> {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| refresh(state, request).await).await
     }
 
-    async fn pause(&self, request: tonic::Request<()>) -> Result<tonic::Response<()>, tonic::Status> {
+    async fn pause(&self, request: tonic::Request<()>) -> Result<tonic::Response<command::Response>, tonic::Status> {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| pause(state, request).await).await
     }
 
-    async fn resume(&self, request: tonic::Request<()>) -> Result<tonic::Response<()>, tonic::Status> {
+    async fn resume(&self, request: tonic::Request<()>) -> Result<tonic::Response<command::Response>, tonic::Status> {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| resume(state, request).await).await
+    }
+
+    async fn update_stream(
+        &self,
+        request: tonic::Request<vessel_command::UpdateStream>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
+        let state = self.state.clone();
+
+        grpc::handle(request, async move |request| update_stream(state, request).await).await
+    }
+
+    async fn add_tag(
+        &self,
+        request: tonic::Request<vessel_command::AddTag>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
+        let state = self.state.clone();
+
+        grpc::handle(request, async move |request| add_tag(state, request).await).await
+    }
+
+    async fn remove_tag(
+        &self,
+        request: tonic::Request<vessel_command::RemoveTag>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
+        let state = self.state.clone();
+
+        grpc::handle(request, async move |request| remove_tag(state, request).await).await
+    }
+
+    async fn upgrade_format(
+        &self,
+        request: tonic::Request<vessel_command::FormatUpgrade>,
+    ) -> Result<tonic::Response<command::Response>, tonic::Status> {
+        let state = self.state.clone();
+
+        grpc::handle(request, async move |request| upgrade_format(state, request).await).await
     }
 
     async fn builder(
@@ -118,7 +163,7 @@ impl GrpcSummitService for SummitService {
         task_id = %request.get_ref().task_id,
     )
 )]
-async fn retry(state: Arc<State>, request: tonic::Request<RetryRequest>) -> Result<(), Error> {
+async fn retry(state: Arc<State>, request: tonic::Request<command::Retry>) -> Result<command::Response, Error> {
     let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
@@ -131,7 +176,10 @@ async fn retry(state: Arc<State>, request: tonic::Request<RetryRequest>) -> Resu
         task_id: (request.into_inner().task_id as i64).into(),
     });
 
-    Ok(())
+    Ok(command::Response {
+        success: true,
+        error: None,
+    })
 }
 
 #[tracing::instrument(
@@ -140,7 +188,7 @@ async fn retry(state: Arc<State>, request: tonic::Request<RetryRequest>) -> Resu
         task_id = %request.get_ref().task_id,
     )
 )]
-async fn cancel(state: Arc<State>, request: tonic::Request<CancelRequest>) -> Result<(), Error> {
+async fn cancel(state: Arc<State>, request: tonic::Request<command::Cancel>) -> Result<command::Response, Error> {
     let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
@@ -153,11 +201,14 @@ async fn cancel(state: Arc<State>, request: tonic::Request<CancelRequest>) -> Re
         task_id: (request.into_inner().task_id as i64).into(),
     });
 
-    Ok(())
+    Ok(command::Response {
+        success: true,
+        error: None,
+    })
 }
 
 #[tracing::instrument(skip_all)]
-async fn refresh(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
+async fn refresh(state: Arc<State>, request: tonic::Request<()>) -> Result<command::Response, Error> {
     let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
@@ -168,11 +219,14 @@ async fn refresh(state: Arc<State>, request: tonic::Request<()>) -> Result<(), E
 
     let _ = state.worker.send(worker::Message::ForceRefresh);
 
-    Ok(())
+    Ok(command::Response {
+        success: true,
+        error: None,
+    })
 }
 
 #[tracing::instrument(skip_all)]
-async fn pause(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
+async fn pause(state: Arc<State>, request: tonic::Request<()>) -> Result<command::Response, Error> {
     let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
@@ -183,11 +237,14 @@ async fn pause(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Err
 
     let _ = state.worker.send(worker::Message::Pause);
 
-    Ok(())
+    Ok(command::Response {
+        success: true,
+        error: None,
+    })
 }
 
 #[tracing::instrument(skip_all)]
-async fn resume(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Error> {
+async fn resume(state: Arc<State>, request: tonic::Request<()>) -> Result<command::Response, Error> {
     let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
 
     info!(
@@ -198,7 +255,158 @@ async fn resume(state: Arc<State>, request: tonic::Request<()>) -> Result<(), Er
 
     let _ = state.worker.send(worker::Message::Resume);
 
-    Ok(())
+    Ok(command::Response {
+        success: true,
+        error: None,
+    })
+}
+
+#[tracing::instrument(skip_all)]
+async fn update_stream(
+    state: Arc<State>,
+    request: tonic::Request<vessel_command::UpdateStream>,
+) -> Result<command::Response, Error> {
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
+
+    info!(
+        session_id = %session.id,
+        client = %session.client,
+        "Update stream"
+    );
+
+    let (send, recv) = oneshot::channel();
+
+    let _ = state.worker.send(worker::Message::RepositoryManager(
+        state.config.repository_manager.id.clone(),
+        state.config.repository_manager.public_key,
+        repository_manager::Message::Command {
+            command: VesselCommand::UpdateStream(request.into_inner()),
+            resp: send,
+        },
+    ));
+
+    let Ok(resp) = recv.await else {
+        return Ok(command::Response {
+            success: false,
+            error: Some("internal error".to_owned()),
+        });
+    };
+
+    Ok(command::Response {
+        success: resp.success,
+        error: resp.error,
+    })
+}
+
+#[tracing::instrument(skip_all)]
+async fn add_tag(
+    state: Arc<State>,
+    request: tonic::Request<vessel_command::AddTag>,
+) -> Result<command::Response, Error> {
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
+
+    info!(
+        session_id = %session.id,
+        client = %session.client,
+        "Add tag"
+    );
+
+    let (send, recv) = oneshot::channel();
+
+    let _ = state.worker.send(worker::Message::RepositoryManager(
+        state.config.repository_manager.id.clone(),
+        state.config.repository_manager.public_key,
+        repository_manager::Message::Command {
+            command: VesselCommand::AddTag(request.into_inner()),
+            resp: send,
+        },
+    ));
+
+    let Ok(resp) = recv.await else {
+        return Ok(command::Response {
+            success: false,
+            error: Some("internal error".to_owned()),
+        });
+    };
+
+    Ok(command::Response {
+        success: resp.success,
+        error: resp.error,
+    })
+}
+
+#[tracing::instrument(skip_all)]
+async fn remove_tag(
+    state: Arc<State>,
+    request: tonic::Request<vessel_command::RemoveTag>,
+) -> Result<command::Response, Error> {
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
+
+    info!(
+        session_id = %session.id,
+        client = %session.client,
+        "Remove tag"
+    );
+
+    let (send, recv) = oneshot::channel();
+
+    let _ = state.worker.send(worker::Message::RepositoryManager(
+        state.config.repository_manager.id.clone(),
+        state.config.repository_manager.public_key,
+        repository_manager::Message::Command {
+            command: VesselCommand::RemoveTag(request.into_inner()),
+            resp: send,
+        },
+    ));
+
+    let Ok(resp) = recv.await else {
+        return Ok(command::Response {
+            success: false,
+            error: Some("internal error".to_owned()),
+        });
+    };
+
+    Ok(command::Response {
+        success: resp.success,
+        error: resp.error,
+    })
+}
+
+#[tracing::instrument(skip_all)]
+async fn upgrade_format(
+    state: Arc<State>,
+    request: tonic::Request<vessel_command::FormatUpgrade>,
+) -> Result<command::Response, Error> {
+    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
+
+    info!(
+        session_id = %session.id,
+        client = %session.client,
+        "Upgrade format"
+    );
+
+    let (send, recv) = oneshot::channel();
+
+    let _ = state.worker.send(worker::Message::RepositoryManager(
+        state.config.repository_manager.id.clone(),
+        state.config.repository_manager.public_key,
+        repository_manager::Message::Command {
+            command: VesselCommand::UpgradeFormat(request.into_inner()),
+            resp: send,
+        },
+    ));
+
+    let Ok(resp) = recv.await else {
+        return Ok(command::Response {
+            success: false,
+            error: Some("internal error".to_owned()),
+        });
+    };
+
+    Ok(command::Response {
+        success: resp.success,
+        error: resp.error,
+    })
 }
 
 #[tracing::instrument(skip_all, fields(builder_id, public_key))]
@@ -442,6 +650,13 @@ async fn repository_manager(
                         repository_manager::Message::ImportFailed {
                             task_id: task::Id::from(task_id as i64),
                         },
+                    ));
+                }
+                repository_manager_stream::incoming::Event::Command(response) => {
+                    let _ = state.worker.send(worker::Message::RepositoryManager(
+                        repository_manager_id.clone(),
+                        public_key,
+                        repository_manager::Message::CommandResponse(response),
                     ));
                 }
             }

--- a/crates/summit/src/repository_manager.rs
+++ b/crates/summit/src/repository_manager.rs
@@ -1,12 +1,19 @@
+use std::collections::HashMap;
+
 use color_eyre::eyre::{Context as _, OptionExt as _, Result};
 use http::Uri;
 use serde::Deserialize;
 use service::{
     crypto::PublicKey,
-    grpc::proto::{common::Collectable, summit::repository_manager_stream},
+    grpc::proto::{
+        common::Collectable,
+        summit::repository_manager_stream,
+        vessel::command::{self, inner::Command},
+    },
 };
-use tokio::sync::mpsc;
-use tracing::{error, info};
+use tokio::sync::{mpsc, oneshot};
+use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use crate::task;
 
@@ -28,6 +35,11 @@ pub enum Message {
     ImportFailed {
         task_id: task::Id,
     },
+    Command {
+        command: Command,
+        resp: oneshot::Sender<command::Response>,
+    },
+    CommandResponse(command::Response),
 }
 
 #[derive(Debug)]
@@ -59,6 +71,7 @@ pub struct Config {
 pub struct RepositoryManager {
     pub config: Config,
     connection: Option<Connection>,
+    pending_commands: HashMap<String, oneshot::Sender<command::Response>>,
 }
 
 impl RepositoryManager {
@@ -66,6 +79,7 @@ impl RepositoryManager {
         Self {
             config,
             connection: None,
+            pending_commands: HashMap::new(),
         }
     }
 
@@ -140,6 +154,61 @@ impl RepositoryManager {
                 info!(%task_id, "Import failed");
                 Some(Event::ImportFailed { task_id })
             }
+            Message::Command { command, resp } => {
+                let request_id = Uuid::new_v4().to_string();
+
+                match &self.connection {
+                    Some(connection) => {
+                        if connection
+                            .handle
+                            .sender
+                            .send(repository_manager_stream::Outgoing {
+                                event: Some(repository_manager_stream::outgoing::Event::Command(command::Request {
+                                    request_id: request_id.clone(),
+                                    command: Some(command::Inner { command: Some(command) }),
+                                })),
+                            })
+                            .await
+                            .is_err()
+                        {
+                            let _ = resp.send(command::Response {
+                                request_id,
+                                success: false,
+                                error: Some("internal error".to_owned()),
+                            });
+
+                            return None;
+                        }
+
+                        self.pending_commands.insert(request_id, resp);
+
+                        None
+                    }
+                    None => {
+                        warn!("Repository manager disconnected while forwarding command");
+
+                        let _ = resp.send(command::Response {
+                            request_id,
+                            success: false,
+                            error: Some("disconnected".to_owned()),
+                        });
+
+                        None
+                    }
+                }
+            }
+            Message::CommandResponse(resp) => match self.pending_commands.remove(&resp.request_id) {
+                Some(sender) => {
+                    let _ = sender.send(resp);
+
+                    None
+                }
+                None => {
+                    warn!("Pending command missing after response received");
+
+                    None
+                }
+            },
         }
     }
 }

--- a/crates/vessel/src/grpc.rs
+++ b/crates/vessel/src/grpc.rs
@@ -1,19 +1,15 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use color_eyre::eyre::{OptionExt as _, Report, bail, eyre};
 use futures_util::TryStreamExt;
 use prost::Message;
 use service::{
-    Session,
     grpc::{
         self,
         proto::{
-            self,
             summit::builder_stream::BuildFinished,
             vessel::{
-                AddTagRequest, CommandResponse, RemoveTagRequest, UpdateStreamRequest, UpgradeFormatRequest,
-                UploadRequest, upgrade_format,
+                UploadRequest,
                 vessel_service_server::{VesselService as GrpcVesselService, VesselServiceServer},
             },
         },
@@ -21,15 +17,10 @@ use service::{
     token::VerifiedToken,
 };
 use snafu::{OptionExt, ResultExt, Snafu};
-use tokio::sync::{mpsc, oneshot};
-use tracing::{Span, error, info, warn};
+use tokio::sync::mpsc;
+use tracing::{Span, info, warn};
 
-use crate::{
-    channel::{self, FormatUpgrade},
-    upload, worker,
-};
-
-pub use service::grpc::auth::service as auth_service;
+use crate::{upload, worker};
 
 pub fn vessel_service(state: service::State, worker: worker::Sender) -> VesselServiceServer<VesselService> {
     VesselServiceServer::new(VesselService {
@@ -57,42 +48,6 @@ impl GrpcVesselService for VesselService {
         let state = self.state.clone();
 
         grpc::handle(request, async move |request| upload(state, request).await).await
-    }
-
-    async fn update_stream(
-        &self,
-        request: tonic::Request<UpdateStreamRequest>,
-    ) -> Result<tonic::Response<CommandResponse>, tonic::Status> {
-        let state = self.state.clone();
-
-        grpc::handle(request, async move |request| update_stream(state, request).await).await
-    }
-
-    async fn add_tag(
-        &self,
-        request: tonic::Request<AddTagRequest>,
-    ) -> Result<tonic::Response<CommandResponse>, tonic::Status> {
-        let state = self.state.clone();
-
-        grpc::handle(request, async move |request| add_tag(state, request).await).await
-    }
-
-    async fn remove_tag(
-        &self,
-        request: tonic::Request<RemoveTagRequest>,
-    ) -> Result<tonic::Response<CommandResponse>, tonic::Status> {
-        let state = self.state.clone();
-
-        grpc::handle(request, async move |request| remove_tag(state, request).await).await
-    }
-
-    async fn upgrade_format(
-        &self,
-        request: tonic::Request<UpgradeFormatRequest>,
-    ) -> Result<tonic::Response<CommandResponse>, tonic::Status> {
-        let state = self.state.clone();
-
-        grpc::handle(request, async move |request| upgrade_format(state, request).await).await
     }
 }
 
@@ -146,253 +101,10 @@ async fn upload(state: Arc<State>, request: tonic::Request<tonic::Streaming<Uplo
     Ok(())
 }
 
-#[tracing::instrument(
-    skip_all,
-    fields(
-        channel = %request.get_ref().channel,
-        stream = ?request.get_ref().stream(),
-        version = %request.get_ref().version,
-    )
-)]
-async fn update_stream(
-    state: Arc<State>,
-    request: tonic::Request<UpdateStreamRequest>,
-) -> Result<CommandResponse, Error> {
-    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
-
-    info!(
-        session_id = %session.id,
-        client = %session.client,
-        "Update stream request received"
-    );
-
-    let body = request.into_inner();
-
-    let (sender, receiver) = oneshot::channel();
-
-    let validate = || -> Result<_, Report> {
-        let stream = match body.stream() {
-            proto::vessel::Stream::Unknown => bail!("unknown stream"),
-            proto::vessel::Stream::Volatile => channel::version::Stream::Volatile,
-            proto::vessel::Stream::Unstable => channel::version::Stream::Unstable,
-        };
-        let version =
-            channel::Version::try_from(body.version).map_err(|err| eyre!("failed to parse version: {err}"))?;
-
-        Ok(worker::Message::ChannelCommand {
-            channel: body.channel,
-            command: channel::Command::UpdateStream { stream, version },
-            response: sender,
-        })
-    };
-
-    match validate() {
-        Ok(command) => {
-            let _ = state.worker.send(command);
-        }
-        Err(error) => {
-            return Ok(CommandResponse {
-                success: false,
-                error: Some(format!("{error:#}")),
-            });
-        }
-    }
-
-    match receiver.await? {
-        Ok(_) => Ok(CommandResponse {
-            success: true,
-            error: None,
-        }),
-        Err(error) => Ok(CommandResponse {
-            success: false,
-            error: Some(format!("{error:#}")),
-        }),
-    }
-}
-
-#[tracing::instrument(
-    skip_all,
-    fields(
-        channel = %request.get_ref().channel,
-        tag = ?request.get_ref().tag,
-        history = %request.get_ref().history,
-    )
-)]
-async fn add_tag(state: Arc<State>, request: tonic::Request<AddTagRequest>) -> Result<CommandResponse, Error> {
-    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
-
-    info!(
-        session_id = %session.id,
-        client = %session.client,
-        "Add tag request received"
-    );
-
-    let body = request.into_inner();
-
-    let (sender, receiver) = oneshot::channel();
-
-    let validate = || -> Result<_, Report> {
-        let tag = channel::version::Identifier::new(&body.tag)?.into();
-        let history = channel::version::Identifier::new(&body.history)?.into();
-
-        Ok(worker::Message::ChannelCommand {
-            channel: body.channel,
-            command: channel::Command::AddTag { tag, history },
-            response: sender,
-        })
-    };
-
-    match validate() {
-        Ok(command) => {
-            let _ = state.worker.send(command);
-        }
-        Err(error) => {
-            return Ok(CommandResponse {
-                success: false,
-                error: Some(format!("{error:#}")),
-            });
-        }
-    }
-
-    match receiver.await? {
-        Ok(_) => Ok(CommandResponse {
-            success: true,
-            error: None,
-        }),
-        Err(error) => Ok(CommandResponse {
-            success: false,
-            error: Some(format!("{error:#}")),
-        }),
-    }
-}
-
-#[tracing::instrument(
-    skip_all,
-    fields(
-        channel = %request.get_ref().channel,
-        tag = ?request.get_ref().tag,
-    )
-)]
-async fn remove_tag(state: Arc<State>, request: tonic::Request<RemoveTagRequest>) -> Result<CommandResponse, Error> {
-    let session = request.extensions().get::<Session>().ok_or(Error::NoActiveSession)?;
-
-    info!(
-        session_id = %session.id,
-        client = %session.client,
-        "Remove tag request received"
-    );
-
-    let body = request.into_inner();
-
-    let (sender, receiver) = oneshot::channel();
-
-    let validate = || -> Result<_, Report> {
-        let tag = channel::version::Identifier::new(&body.tag)?.into();
-
-        Ok(worker::Message::ChannelCommand {
-            channel: body.channel,
-            command: channel::Command::RemoveTag { tag },
-            response: sender,
-        })
-    };
-
-    match validate() {
-        Ok(command) => {
-            let _ = state.worker.send(command);
-        }
-        Err(error) => {
-            return Ok(CommandResponse {
-                success: false,
-                error: Some(format!("{error:#}")),
-            });
-        }
-    }
-
-    match receiver.await? {
-        Ok(_) => Ok(CommandResponse {
-            success: true,
-            error: None,
-        }),
-        Err(error) => Ok(CommandResponse {
-            success: false,
-            error: Some(format!("{error:#}")),
-        }),
-    }
-}
-
-#[tracing::instrument(
-    skip_all,
-    fields(
-        channel = %request.get_ref().channel,
-        format,
-    )
-)]
-async fn upgrade_format(
-    state: Arc<State>,
-    request: tonic::Request<UpgradeFormatRequest>,
-) -> Result<CommandResponse, Error> {
-    let body = request.into_inner();
-
-    let format_upgrade = body.format.and_then(|f| match f.format? {
-        upgrade_format::Format::Legacy(request) => Some(FormatUpgrade::Legacy {
-            tag_name: request.tag_name,
-        }),
-    });
-
-    if let Some(format) = format_upgrade.as_ref() {
-        Span::current().record("format", format.to_string());
-    }
-
-    info!("Upgrade format request received");
-
-    let (sender, receiver) = oneshot::channel();
-
-    let validate = || -> Result<_, Report> {
-        let format_upgrade = format_upgrade.ok_or_eyre("missing format")?;
-
-        Ok(worker::Message::ChannelCommand {
-            channel: body.channel,
-            command: channel::Command::FormatUpgrade(format_upgrade),
-            response: sender,
-        })
-    };
-
-    match validate() {
-        Ok(command) => {
-            let _ = state.worker.send(command);
-        }
-        Err(err) => {
-            error!(error = format!("{err:#}"), "Upgrade format request validation failed");
-
-            return Ok(CommandResponse {
-                success: false,
-                error: Some(format!("{err:#}")),
-            });
-        }
-    }
-
-    match receiver.await? {
-        Ok(_) => Ok(CommandResponse {
-            success: true,
-            error: None,
-        }),
-        Err(err) => {
-            error!(error = format!("{err:#}"), "Upgrade format command failed");
-
-            Ok(CommandResponse {
-                success: false,
-                error: Some(format!("{err:#}")),
-            })
-        }
-    }
-}
-
 #[derive(Debug, Snafu)]
 enum Error {
     #[snafu(display("Token missing from request"))]
     MissingRequestToken,
-    #[snafu(display("No active session"))]
-    NoActiveSession,
     #[snafu(display("Invalid upload token"))]
     InvalidUploadToken,
     #[snafu(display("Failed to send task to worker"))]
@@ -403,12 +115,8 @@ enum Error {
     GrpcRequest { source: tonic::Status },
     #[snafu(display("Missing upload token body from upload stream"))]
     MissingUploadTokenRequest,
-    #[snafu(display("Missing upload signature from upload stream"))]
-    MissingUploadSignatureRequest,
     #[snafu(display("Failed to decode upload token body"))]
     DecodeUploadTokenRequest { source: prost::DecodeError },
-    #[snafu(transparent)]
-    OneshotRecv { source: oneshot::error::RecvError },
     #[snafu(display("Failed to save packages"))]
     SavePackages { source: upload::Error },
 }
@@ -416,12 +124,12 @@ enum Error {
 impl From<Error> for tonic::Status {
     fn from(error: Error) -> Self {
         match error {
-            Error::MissingRequestToken | Error::NoActiveSession => tonic::Status::unauthenticated(""),
+            Error::MissingRequestToken => tonic::Status::unauthenticated(""),
             Error::InvalidUploadToken => tonic::Status::permission_denied(""),
-            Error::MissingUploadTokenRequest
-            | Error::MissingUploadSignatureRequest
-            | Error::DecodeUploadTokenRequest { .. } => tonic::Status::invalid_argument(""),
-            Error::SendWorker { .. } | Error::OneshotRecv { .. } => tonic::Status::internal(""),
+            Error::MissingUploadTokenRequest | Error::DecodeUploadTokenRequest { .. } => {
+                tonic::Status::invalid_argument("")
+            }
+            Error::SendWorker { .. } => tonic::Status::internal(""),
             Error::GrpcRequest { source } => source,
             Error::SavePackages { source } => match source {
                 upload::Error::Sha256Mismatch { .. }

--- a/crates/vessel/src/main.rs
+++ b/crates/vessel/src/main.rs
@@ -3,7 +3,6 @@ use std::{net::IpAddr, path::PathBuf};
 use channel::DEFAULT_CHANNEL;
 use clap::Parser;
 use color_eyre::eyre::Context;
-use service::auth::AuthorizedServices;
 use service::{Server, Service, buildinfo, error};
 use tracing::{error, info};
 
@@ -20,8 +19,6 @@ mod state;
 mod stream;
 mod upload;
 mod worker;
-
-pub const SERVICE: Service = Service::Vessel;
 
 pub type Result<T, E = color_eyre::eyre::Error> = std::result::Result<T, E>;
 
@@ -69,23 +66,14 @@ async fn main() -> Result<()> {
 
     let (worker_sender, worker_events, worker_task) = worker::run(state.clone()).await?;
 
-    Server::new(SERVICE, &state.service, config.admin.clone())
+    Server::new(Service::Vessel, &state.service, config.admin.clone())
         .with_task("worker", worker_task)
-        .with_task("stream", stream::run(state.clone(), config.clone(), worker_events))
+        .with_task(
+            "stream",
+            stream::run(state.clone(), config.clone(), worker_sender.clone(), worker_events),
+        )
         .with_grpc((host, grpc_port), |routes| {
-            routes
-                .add_service(grpc::auth_service(
-                    SERVICE,
-                    state.service_db().clone(),
-                    state.service.key_pair.clone(),
-                    state.service.active_sessions.clone(),
-                    // No services auth w/ vessel, only admin accounts
-                    //
-                    // TODO: route all vessel commands via
-                    // summit -> stream
-                    AuthorizedServices::default(),
-                ))
-                .add_service(grpc::vessel_service(state.service.clone(), worker_sender));
+            routes.add_service(grpc::vessel_service(state.service.clone(), worker_sender));
         })
         .start()
         .await?;

--- a/crates/vessel/src/stream.rs
+++ b/crates/vessel/src/stream.rs
@@ -1,20 +1,28 @@
 use std::{convert::Infallible, time::Duration};
 
-use color_eyre::eyre::{Context, OptionExt as _, Result};
+use color_eyre::eyre::{Context, OptionExt as _, Result, bail, eyre};
 use service::{
     Service,
     client::{AuthClient as _, Credentials, CredentialsAuth, InMemoryTokenStorage, SummitServiceClient},
     error,
-    grpc::proto::summit::repository_manager_stream,
+    grpc::proto::{
+        summit::repository_manager_stream,
+        vessel::{command, upgrade_format},
+    },
 };
 use tokio::{select, sync::mpsc, time};
 use tokio_stream::{StreamExt, wrappers::ReceiverStream};
 use tracing::{debug, error, info};
 
-use crate::{Config, State, upload, worker};
+use crate::{Config, State, channel, upload, worker};
 
-pub async fn run(state: State, config: Config, worker_events: worker::EventReceiver) -> Result<(), Infallible> {
-    connect(&state, &config, worker_events).await;
+pub async fn run(
+    state: State,
+    config: Config,
+    worker_sender: worker::Sender,
+    worker_events: worker::EventReceiver,
+) -> Result<(), Infallible> {
+    connect(&state, &config, worker_sender, worker_events).await;
     Ok(())
 }
 
@@ -26,7 +34,12 @@ pub async fn run(state: State, config: Config, worker_events: worker::EventRecei
         public_key = %config.summit.public_key,
     ),
 )]
-async fn connect(state: &State, config: &Config, mut worker_events: worker::EventReceiver) {
+async fn connect(
+    state: &State,
+    config: &Config,
+    mut worker_sender: worker::Sender,
+    mut worker_events: worker::EventReceiver,
+) {
     // Create auth credentials up here so it'll live longer than our `connect_inner` loop
     // and we can reuse access tokens across broken connections / reconnect loop
     let auth = CredentialsAuth::with_in_memory_storage(Credentials::Service {
@@ -42,7 +55,7 @@ async fn connect(state: &State, config: &Config, mut worker_events: worker::Even
     loop {
         debug!("Attempting to connect to summit");
 
-        if let Err(e) = connect_inner(state, config, auth.clone(), &mut worker_events).await {
+        if let Err(e) = connect_inner(state, config, auth.clone(), &mut worker_sender, &mut worker_events).await {
             let error = error::chain(&*e);
             error!(%error, "Stream error");
 
@@ -56,6 +69,7 @@ async fn connect_inner(
     state: &State,
     config: &Config,
     auth: CredentialsAuth<InMemoryTokenStorage>,
+    worker_sender: &mut worker::Sender,
     worker_events: &mut worker::EventReceiver,
 ) -> Result<()> {
     let mut client = SummitServiceClient::connect_with_auth(config.summit.host_address.clone(), None, auth)
@@ -112,6 +126,20 @@ async fn connect_inner(
 
                             debug!(%task_id, "Import failed reported");
                         },
+                        worker::Event::CommandFinished { request_id, result } => {
+                            let _ = sender.send(repository_manager_stream::Incoming {
+                                event: Some(repository_manager_stream::incoming::Event::Command(
+                                    command::Response {
+                                        request_id: request_id.clone(),
+                                        success: result.is_ok(),
+                                        error: result.err().map(|err| format!("{err:#}")),
+                                    }
+                                ))
+                            })
+                            .await;
+
+                            debug!(%request_id, "Command status reported");
+                        },
                     }
                 }
             }
@@ -139,6 +167,44 @@ async fn connect_inner(
                                 "Upload token issued for task"
                             );
                         },
+                        repository_manager_stream::outgoing::Event::Command(request) => {
+                            let request_id = request.request_id.clone();
+
+                            match parse_channel_command(request) {
+                                Ok((channel, command)) => {
+                                    info!(
+                                        %request_id,
+                                        %channel,
+                                        %command,
+                                        "Command received"
+                                    );
+
+                                    let _ = worker_sender.send(worker::Message::ChannelCommand {
+                                        request_id,
+                                        channel,
+                                        command,
+                                    });
+                                }
+                                Err(err) => {
+                                    error!(
+                                        %request_id,
+                                        error = format!("{err:#}"),
+                                        "Failed to parse incoming command"
+                                    );
+
+                                    let _ = sender.send(repository_manager_stream::Incoming {
+                                        event: Some(repository_manager_stream::incoming::Event::Command(
+                                            command::Response {
+                                                request_id,
+                                                success: false,
+                                                error: Some(format!("{err:#}"))
+                                            }
+                                        ))
+                                    })
+                                    .await;
+                                }
+                            }
+                        }
                     }
                 } else {
                     break;
@@ -149,4 +215,51 @@ async fn connect_inner(
     }
 
     Ok(())
+}
+
+fn parse_channel_command(request: command::Request) -> Result<(String, channel::Command)> {
+    match request
+        .command
+        .and_then(|inner| inner.command)
+        .ok_or_eyre("malformed grpc request")?
+    {
+        command::inner::Command::UpdateStream(command) => Ok((
+            command.channel.clone(),
+            channel::Command::UpdateStream {
+                stream: match command.stream() {
+                    service::grpc::proto::vessel::Stream::Volatile => channel::version::Stream::Volatile,
+                    service::grpc::proto::vessel::Stream::Unstable => channel::version::Stream::Unstable,
+                    _ => bail!("unknown stream"),
+                },
+                version: channel::Version::try_from(command.version)
+                    .map_err(|err| eyre!("failed to parse version: {err}"))?,
+            },
+        )),
+        command::inner::Command::AddTag(command) => Ok((
+            command.channel,
+            channel::Command::AddTag {
+                tag: channel::version::Identifier::new(&command.tag)?.into(),
+                history: channel::version::Identifier::new(&command.history)?.into(),
+            },
+        )),
+        command::inner::Command::RemoveTag(command) => Ok((
+            command.channel,
+            channel::Command::RemoveTag {
+                tag: channel::version::Identifier::new(&command.tag)?.into(),
+            },
+        )),
+        command::inner::Command::UpgradeFormat(command) => Ok((
+            command.channel,
+            channel::Command::FormatUpgrade(
+                command
+                    .format
+                    .and_then(|f| match f.format? {
+                        upgrade_format::Format::Legacy(request) => Some(channel::FormatUpgrade::Legacy {
+                            tag_name: request.tag_name,
+                        }),
+                    })
+                    .ok_or_eyre("missing format")?,
+            ),
+        )),
+    }
 }

--- a/crates/vessel/src/worker.rs
+++ b/crates/vessel/src/worker.rs
@@ -2,7 +2,7 @@ use std::{convert::Infallible, future::Future, time::Duration};
 
 use color_eyre::eyre::Result;
 use tokio::{
-    sync::{mpsc, oneshot},
+    sync::mpsc,
     time::{self, Instant},
 };
 use tracing::{Instrument, error, info, info_span};
@@ -29,9 +29,9 @@ pub enum Message {
     Prune(Instant),
     #[strum(serialize = "channel-command-{command}")]
     ChannelCommand {
+        request_id: String,
         channel: String,
         command: channel::Command,
-        response: oneshot::Sender<Result<()>>,
     },
 }
 
@@ -40,6 +40,7 @@ pub enum Message {
 pub enum Event {
     ImportSucceeded { task_id: u64 },
     ImportFailed { task_id: u64 },
+    CommandFinished { request_id: String, result: Result<()> },
 }
 
 pub async fn run(
@@ -116,9 +117,9 @@ async fn handle_message(state: &State, message: Message, events: &mpsc::Unbounde
         }
         Message::Prune(_) => channel::prune(state, DEFAULT_CHANNEL).await,
         Message::ChannelCommand {
+            request_id,
             channel,
             command,
-            response,
         } => {
             let result = channel::handle_command(state, &channel, command).await;
 
@@ -127,7 +128,7 @@ async fn handle_message(state: &State, message: Message, events: &mpsc::Unbounde
                 error!(%error, "Failed to handle command");
             }
 
-            let _ = response.send(result);
+            let _ = events.send(Event::CommandFinished { request_id, result });
 
             Ok(())
         }


### PR DESCRIPTION
By forcing vessel commands over summit, we can remove the auth service from vessel and limit its grpc surface to just package uploads via single use / scoped tokens.

Summit can then become the single source of truth for all auth / session management.

This also adds all the plumbing necessary to easily invoke these same commands from a future summit web admin dashboard via the connected stream.