### PR TITLE
vessel: Dont hold db tx across multiple FS operations

### DIFF
--- a/crates/avalanche/src/stream.rs
+++ b/crates/avalanche/src/stream.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::{Context, OptionExt, Result};
 use futures_util::{TryStreamExt, future::join_all};
 use service::{
     Service, State,
-    client::{AuthClient, Credentials, CredentialsAuth, InMemoryTokenStorage, SummitServiceClient},
+    client::{AuthClient, Credentials, CredentialsAuth, SummitServiceClient},
     crypto::PublicKey,
     error,
     grpc::proto::{common::Collectable, summit::builder_stream},

--- a/crates/service-grpc/build.rs
+++ b/crates/service-grpc/build.rs
@@ -80,7 +80,7 @@ impl ServiceGenerator for Generator {
         buf.push_str("#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]");
         buf.push_str("pub enum Method {");
         for (method, _, _) in &methods {
-            buf.push_str(&format!("\n{},", &method.proto_name));
+            buf.push_str(&format!("\n{},", method.proto_name));
         }
         buf.push_str("\n}");
 

--- a/crates/vessel/src/channel/db.rs
+++ b/crates/vessel/src/channel/db.rs
@@ -425,10 +425,10 @@ pub async fn link_version_to_history(
     Ok(())
 }
 
-/// Delete all history versions that aren't currently linked against
+/// Returns all history versions that aren't currently linked against
 /// and are created before the provided time
-pub async fn delete_stale_history(
-    tx: &mut Transaction,
+pub async fn list_stale_history(
+    conn: &mut SqliteConnection,
     channel: &str,
     created_before: DateTime<Utc>,
 ) -> sqlx::Result<Vec<HistoryVersion>> {
@@ -443,24 +443,49 @@ pub async fn delete_stale_history(
             channel = ?
             AND history_id IS NOT NULL
         )
-        DELETE FROM
+        SELECT
+          channel_version_id,
+          version,
+          format
+        FROM
           channel_version
         WHERE
           channel = ?
           AND version LIKE 'history/%'
           AND channel_version_id NOT IN (SELECT * FROM referenced_history)
           AND created < ?
-        RETURNING
-          channel_version_id,
-          version,
-          format
         ",
     )
     .bind(channel)
     .bind(channel)
     .bind(created_before.timestamp())
-    .fetch_all(tx.as_mut())
+    .fetch_all(conn)
     .await
+}
+
+/// Delete the provided channel history
+pub async fn delete_history(tx: &mut Transaction, channel: &str, history: &HistoryVersion) -> Result<()> {
+    let result = sqlx::query(
+        "
+        DELETE FROM
+          channel_version
+        WHERE
+          channel = ?
+          AND channel_version_id = ?
+        ",
+    )
+    .bind(channel)
+    .bind(history.channel_version_id)
+    .execute(tx.as_mut())
+    .await?;
+
+    ensure!(
+        result.rows_affected() == 1,
+        "{} doesn't exist in channel {channel}",
+        history.version,
+    );
+
+    Ok(())
 }
 
 /// Add a tag
@@ -664,12 +689,14 @@ mod test {
         record_history(&mut tx, CHANNEL, &[], &FORMAT).await.unwrap();
 
         // Previous 3 states should be removable
-        let deleted = delete_stale_history(&mut tx, CHANNEL, cutoff)
-            .await
-            .unwrap()
-            .into_iter()
-            .map(|h| h.version)
-            .collect::<HashSet<_>>();
+        let stale = list_stale_history(tx.as_mut(), CHANNEL, cutoff).await.unwrap();
+
+        let mut deleted = HashSet::new();
+
+        for history in stale {
+            delete_history(&mut tx, CHANNEL, &history).await.unwrap();
+            deleted.insert(history.version);
+        }
 
         assert_eq!(deleted, deletable);
     }

--- a/crates/vessel/src/channel/prune.rs
+++ b/crates/vessel/src/channel/prune.rs
@@ -28,36 +28,54 @@ async fn prune_stale_versions(state: &State, channel: &str) -> Result<()> {
     // TODO: Configurable
     const STALE_AFTER: Duration = Duration::from_secs(60 * 60 * 24 * 14);
 
-    let mut tx = state.service_db().begin().await.context("begin db tx")?;
-
     let created_before = Utc::now() - chrono::Duration::from_std(STALE_AFTER).expect("within i64");
 
     info!(%created_before, "Checking for stale history");
 
-    let deleted = db::delete_stale_history(&mut tx, channel, created_before)
-        .await
-        .context("delete stale history")?;
+    let stale_history = db::list_stale_history(
+        state.service_db().acquire().await.context("acquire db conn")?.as_mut(),
+        channel,
+        created_before,
+    )
+    .await
+    .context("list stale history")?;
 
-    if deleted.is_empty() {
+    if stale_history.is_empty() {
         info!("No stale history");
         return Ok(());
     }
 
-    for d in &deleted {
-        // Only history versions are returned from prune stale history
-        let channel::Version::History { identifier: history } = &d.version else {
+    for history in &stale_history {
+        // Only history versions are returned from list stale history
+        let channel::Version::History { identifier } = &history.version else {
             continue;
         };
 
         // Remove from filesystem
-        let _ = fs::remove_dir_all(state.public_dir().join(channel).join(history.relative_base_dir())).await;
+        //
+        // Ignore error since DB operation can't be atomic w/ FS operation
+        // and the committed DB operation is the source of truth. If a DB commit
+        // fails _after_ the FS operation, we can safely retry and the
+        // folder will already be deleted, which is fine.
+        let _ = fs::remove_dir_all(state.public_dir().join(channel).join(identifier.relative_base_dir())).await;
 
-        info!(version = %d.version, "History deleted");
+        // Remove from DB
+        //
+        // Commits the removal of this history from state
+        {
+            let mut tx = state.service_db().begin().await.context("begin db tx")?;
+
+            db::delete_history(&mut tx, channel, history)
+                .await
+                .context("delete db history")?;
+
+            tx.commit().await.context("commit db tx")?;
+        }
+
+        info!(version = %history.version, "History deleted");
     }
 
-    info!("num_deleted" = deleted.len(), "Stale history deleted");
-
-    tx.commit().await.context("commit db tx")?;
+    info!("num_deleted" = stale_history.len(), "Stale history deleted");
 
     Ok(())
 }

--- a/crates/vessel/src/stream.rs
+++ b/crates/vessel/src/stream.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, time::Duration};
 use color_eyre::eyre::{Context, OptionExt as _, Result, bail, eyre};
 use service::{
     Service,
-    client::{AuthClient as _, Credentials, CredentialsAuth, InMemoryTokenStorage, SummitServiceClient},
+    client::{AuthClient as _, Credentials, CredentialsAuth, SummitServiceClient},
     error,
     grpc::proto::{
         summit::repository_manager_stream,


### PR DESCRIPTION
We held a DB tx across multiple FS operations, which can lead to a locked DB error if other threads need to write.

This is technically no longer an issue as we've removed DB writes on async grpc threads (auth), but its still something we need to avoid.

Instead we just execute the DB tx per item being removed _after_ the FS operation, which acts as the deletion "commit". This is idempotent & safe to rerun if interrupted for any reason, we don't need the ENTIRE prune atomically committed. 